### PR TITLE
prevent ruby warning on undefined instance variable

### DIFF
--- a/lib/roda.rb
+++ b/lib/roda.rb
@@ -281,7 +281,9 @@ class Roda
             raise RodaError, "can't provide both argument and block to response_module" if block_given?
             klass.send(:include, mod)
           else
-            unless mod = instance_variable_get(iv)
+            if instance_variable_defined?(iv)
+              mod = instance_variable_get(iv)
+            else
               mod = instance_variable_set(iv, Module.new)
               klass.send(:include, mod)
             end


### PR DESCRIPTION
fixes ruby warning on accessing undefined instance variable

> roda-1.0.0/lib/roda.rb:273: warning: instance variable @request_module not initialized

i wanted to clean other warnings, but it looks there is plenty of them so maybe later: https://gist.github.com/mikz/162b04ea6596cfc71004
