### PR TITLE
fix a typo in README.md

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -780,7 +780,7 @@ By design, Roda has a very small core, providing only the essentials.
 All nonessential features are added via plugins.
 This is why Roda is referred to as a routing tree web framework toolkit.
 Using a combination of Roda plugins,
-you can build the routing tree web framework that needs your needs.
+you can build the routing tree web framework that suits your needs.
 
 Roda's plugins can override any Roda method and call +super+
 to get the default behavior, which makes Roda very extensible.


### PR DESCRIPTION
"needs your needs" is probably meant to be written as "suits your needs".
