### PR TITLE
avoid creating new Hash instances for plugin options where possible

### DIFF
--- a/lib/roda/plugins/caching.rb
+++ b/lib/roda/plugins/caching.rb
@@ -66,6 +66,8 @@ class Roda
     # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     # OTHER DEALINGS IN THE SOFTWARE.
     module Caching
+      OPTS = {}.freeze
+
       module RequestMethods
         LAST_MODIFIED = 'Last-Modified'.freeze
         HTTP_IF_NONE_MATCH = 'HTTP_IF_NONE_MATCH'.freeze
@@ -118,7 +120,7 @@ class Roda
         #
         # When the current request includes an If-Match header with a
         # etag that doesn't match, immediately returns a response with a 412 status.
-        def etag(value, opts={})
+        def etag(value, opts=OPTS)
           # Before touching this code, please double check RFC 2616 14.24 and 14.26.
           weak = opts[:weak]
           new_resource = opts.fetch(:new_resource){post?}
@@ -194,7 +196,7 @@ class Roda
         # be an integer number of seconds that the current request should be
         # cached for.  Also sets the Expires header, useful if you have
         # HTTP 1.0 clients (Cache-Control is an HTTP 1.1 header).
-        def expires(max_age, opts={})
+        def expires(max_age, opts=OPTS)
           cache_control(opts.merge(:max_age=>max_age))
           self[EXPIRES] = (Time.now + max_age).httpdate
         end

--- a/lib/roda/plugins/error_email.rb
+++ b/lib/roda/plugins/error_email.rb
@@ -28,6 +28,7 @@ class Roda
     # for low traffic web applications.  For high traffic web applications,
     # use an error reporting service instead of this plugin.
     module ErrorEmail
+      OPTS = {}.freeze
       DEFAULTS = {
         :headers=>{},
         :host=>'localhost',
@@ -74,7 +75,7 @@ END
       }
 
       # Set default opts for plugin.  See ErrorEmail module RDoc for options.
-      def self.configure(app, opts={})
+      def self.configure(app, opts=OPTS)
         email_opts = app.opts[:error_email] ||= DEFAULTS
         email_opts = email_opts.merge(opts)
         email_opts[:headers] = email_opts[:headers].dup

--- a/lib/roda/plugins/json.rb
+++ b/lib/roda/plugins/json.rb
@@ -33,8 +33,10 @@ class Roda
     #
     #   plugin :json, :classes=>[Array, Hash, Sequel::Model]
     module Json
+      OPTS = {}.freeze
+
       # Set the classes to automatically convert to JSON
-      def self.configure(app, opts={})
+      def self.configure(app, opts=OPTS)
         classes = opts[:classes] || [Array, Hash]
         app.opts[:json_result_classes] ||= []
         app.opts[:json_result_classes] += classes

--- a/lib/roda/plugins/mailer.rb
+++ b/lib/roda/plugins/mailer.rb
@@ -110,6 +110,7 @@ class Roda
       MAIL = "MAIL".freeze
       CONTENT_TYPE = 'Content-Type'.freeze
       TEXT_PLAIN = "text/plain".freeze
+      OPTS = {}.freeze
 
       # Error raised when the using the mail class method, but the routing
       # tree doesn't return the mail object. 
@@ -117,7 +118,7 @@ class Roda
 
       # Set the options for the mailer.  Options:
       # :content_type :: The default content type for emails (default: text/plain)
-      def self.configure(app, opts={})
+      def self.configure(app, opts=OPTS)
         app.opts[:mailer] = (app.opts[:mailer]||{}).merge(opts).freeze
       end
 

--- a/lib/roda/plugins/path.rb
+++ b/lib/roda/plugins/path.rb
@@ -32,10 +32,11 @@ class Roda
     # a block to a block that is instance_execed.
     module Path
       DEFAULT_PORTS = {'http' => 80, 'https' => 443}.freeze
+      OPTS = {}.freeze
 
       module ClassMethods
         # Create a new instance method for the named path.  See plugin module documentation for options.
-        def path(name, path=nil, opts={}, &block)
+        def path(name, path=nil, opts=OPTS, &block)
           if path.is_a?(Hash)
             raise RodaError,  "cannot provide two option hashses to Roda.path" unless opts.empty?
             opts = path

--- a/lib/roda/plugins/render_each.rb
+++ b/lib/roda/plugins/render_each.rb
@@ -23,6 +23,8 @@ class Roda
     # the template will be +bar+.  You can use <tt>:local=>nil</tt> to
     # not set a local variable inside the template.
     module RenderEach
+      OPTS = {}.freeze
+
       # Load the render plugin before this plugin, since this plugin
       # calls the render method.
       def self.load_dependencies(app)
@@ -36,7 +38,7 @@ class Roda
         # :local :: The local variable to use for the current enum value
         #           inside the template.  An explicit +nil+ value does not
         #           set a local variable.  If not set, uses the template name.
-        def render_each(enum, template, opts={})
+        def render_each(enum, template, opts=OPTS)
           if as = opts.has_key?(:local)
             as = opts[:local]
           else

--- a/lib/roda/plugins/streaming.rb
+++ b/lib/roda/plugins/streaming.rb
@@ -50,6 +50,8 @@ class Roda
     # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
     # OTHER DEALINGS IN THE SOFTWARE.
     module Streaming
+      OPTS = {}.freeze
+
       # Class of the response body in case you use #stream.
       #
       # Three things really matter: The front and back block (back being the
@@ -85,7 +87,7 @@ class Roda
         end
 
         # Handle streaming options, see Streaming for details.
-        def initialize(opts={}, &back)
+        def initialize(opts=OPTS, &back)
           @scheduler = opts[:scheduler] || Scheduler.new(self)
           @back = back.to_proc
           @keep_open = opts[:keep_open]
@@ -143,7 +145,7 @@ class Roda
         # Immediately return a streaming response using the current response
         # status and headers, calling the block to get the streaming response.
         # See Streaming for details.
-        def stream(opts={}, &block)
+        def stream(opts=OPTS, &block)
           opts = opts.merge(:scheduler=>EventMachine) if !opts.has_key?(:scheduler) && env['async.callback']
 
           if opts[:loop]


### PR DESCRIPTION
This brings most of the plugins into line with the convention already used in chunked, padrino_render, render, and sinatra_helpers.

I couldn't do it in csrf because the hash is immediately passed to Rack::Csrf which seems to want to mutate it.