### PR TITLE
add json request body parsing to json plugin

### DIFF
--- a/lib/roda/plugins/indifferent_params.rb
+++ b/lib/roda/plugins/indifferent_params.rb
@@ -23,10 +23,19 @@ class Roda
     # you load the plugin into.
     module IndifferentParams
       module InstanceMethods
-        # A copy of the request params that will automatically
-        # convert symbols to strings.
-        def params
-          @_params ||= indifferent_params(request.params)
+
+        # todo: better way of handling `params` between json plugin and this
+        def self.included base
+          unless base.instance_methods.include? :params
+            base.class_eval do
+
+              # A copy of the request params that will automatically
+              # convert symbols to strings.
+              def params
+                @_params ||= indifferent_params(request.params)
+              end
+            end
+          end
         end
 
         private
@@ -35,7 +44,7 @@ class Roda
         # hashes to support indifferent access, leaving
         # other values alone.
         def indifferent_params(params)
-          case params 
+          case params
           when Hash
             hash = Hash.new{|h, k| h[k.to_s] if Symbol === k}
             params.each{|k, v| hash[k] = indifferent_params(v)}
@@ -46,7 +55,7 @@ class Roda
             params
           end
         end
-      end  
+      end
     end
 
     register_plugin(:indifferent_params, IndifferentParams)

--- a/lib/roda/plugins/json.rb
+++ b/lib/roda/plugins/json.rb
@@ -32,8 +32,21 @@ class Roda
     # using the :classes option when loading the plugin:
     #
     #   plugin :json, :classes=>[Array, Hash, Sequel::Model]
+    #
+    # The json plugin also allows request bodies to be parsed and merged
+    # into the hash available via `params`. This `params` method works
+    # in conjunction with indifferent_params plugin if it is included.
+    #
+    # To have Roda parse JSON requests:
+    #
+    #   plugin :json, :request_body => true
+    #
+    # If the request body is unparseable, `response.status` is set to 400.
+    # If the body is an Array, it is parsed and set at `params[:body]`.
+    #
     module Json
       OPTS = {}.freeze
+      APPLICATION_JSON = 'application/json'.freeze
 
       # Set the classes to automatically convert to JSON
       def self.configure(app, opts=OPTS)
@@ -42,6 +55,9 @@ class Roda
         app.opts[:json_result_classes] += classes
         app.opts[:json_result_classes].uniq!
         app.opts[:json_result_classes].freeze
+
+        app.opts[:json_request_body] = !!opts[:request_body]
+        app.opts[:json_request_body].freeze
       end
 
       module ClassMethods
@@ -49,11 +65,14 @@ class Roda
         def json_result_classes
           opts[:json_result_classes]
         end
+
+        def json_request_body?
+          opts[:json_request_body]
+        end
       end
 
       module RequestMethods
         CONTENT_TYPE = 'Content-Type'.freeze
-        APPLICATION_JSON = 'application/json'.freeze
 
         private
 
@@ -75,6 +94,48 @@ class Roda
         def convert_to_json(obj)
           obj.to_json
         end
+      end
+
+      module InstanceMethods
+
+        # Convert the given JSON to object.  Uses `JSON.parse` by default,
+        # but can be overridden to use a different implementation.
+        def convert_body_from_json
+          JSON.parse(request.body.read)
+        rescue JSON::ParserError
+          response.status = 400
+        ensure
+          request.body.rewind
+        end
+
+        # Lazily initialize a `@_params` instance variable, similar to
+        # indifferent_params plugin. Merge objects into params, set Arrays
+        # at params[:body]. Run through `indifferent_params` if available.
+        def params
+          unless @_params
+            @_params = request.params
+            if self.class.json_request_body? and json_request?
+              case b = convert_body_from_json
+              when Hash;  @_params.merge! b
+              when Array; @_params[:body] = b
+              end
+            end
+            @_params = indifferent_params(@_params) rescue @_params
+          end
+          @_params
+        end
+
+        private
+
+        # Rack-style header keys
+        CONTENT_TYPE_KEY = 'CONTENT_TYPE'.freeze
+
+        # Do request headers indicate JSON data?
+        def json_request?
+          request.env.has_key?(CONTENT_TYPE_KEY) and
+            request.env[CONTENT_TYPE_KEY][0,16] == APPLICATION_JSON
+        end
+
       end
     end
 

--- a/spec/plugin/json_spec.rb
+++ b/spec/plugin/json_spec.rb
@@ -1,49 +1,115 @@
 require File.expand_path("spec_helper", File.dirname(File.dirname(__FILE__)))
 
 describe "json plugin" do
-  before do
-    c = Class.new do
-      def to_json
-        '[1]'
+  describe "response conversion" do
+    before do
+      c = Class.new do
+        def to_json
+          '[1]'
+        end
+      end
+
+      app(:bare) do
+        plugin :json, :classes=>[Array, Hash, c]
+
+        route do |r|
+          r.is 'array' do
+            [1, 2, 3]
+          end
+
+          r.is "hash" do
+            {'a'=>'b'}
+          end
+
+          r.is 'c' do
+            c.new
+          end
+        end
       end
     end
 
-    app(:bare) do
-      plugin :json, :classes=>[Array, Hash, c]
+    it "should use a json content type for a json response" do
+      header('Content-Type', "/array").should == 'application/json'
+      header('Content-Type', "/hash").should == 'application/json'
+      header('Content-Type', "/c").should == 'application/json'
+      header('Content-Type').should == 'text/html'
+    end
 
-      route do |r|
-        r.is 'array' do
-          [1, 2, 3]
-        end
+    it "should convert objects to json" do
+      body('/array').gsub(/\s/, '').should == '[1,2,3]'
+      body('/hash').gsub(/\s/, '').should == '{"a":"b"}'
+      body('/c').should == '[1]'
+      body.should == ''
+    end
 
-        r.is "hash" do
-          {'a'=>'b'}
-        end
-
-        r.is 'c' do
-          c.new
-        end
-      end
+    it "should work when subclassing" do
+      @app = Class.new(app)
+      app.route{[1]}
+      body.should == '[1]'
     end
   end
 
-  it "should use a json content type for a json response" do
-    header('Content-Type', "/array").should == 'application/json'
-    header('Content-Type', "/hash").should == 'application/json'
-    header('Content-Type', "/c").should == 'application/json'
-    header('Content-Type').should == 'text/html'
-  end
+  describe "request body" do
 
-  it "should convert objects to json" do
-    body('/array').gsub(/\s/, '').should == '[1,2,3]'
-    body('/hash').gsub(/\s/, '').should == '{"a":"b"}'
-    body('/c').should == '[1]'
-    body.should == ''
-  end
+    let(:hash){ {foo: "bar", baz: 2, bat: true} }
+    let(:json){ hash.to_json }
 
-  it "should work when subclassing" do
-    @app = Class.new(app)
-    app.route{[1]}
-    body.should == '[1]'
+    describe "parsing" do
+      before do
+        app(:bare) do
+          plugin :json, :request_body => true
+
+          route do |r|
+            r.on do
+              params
+            end
+          end
+        end
+      end
+
+
+      it "should parse json request bodies" do
+        body('CONTENT_TYPE'=>'application/json', 'rack.input'=>StringIO.new(json)).should == json
+      end
+
+      it "should merge json values over query string values" do
+        body('CONTENT_TYPE'=>'application/json',
+             'rack.input'=>StringIO.new(json),
+             'QUERY_STRING'=>'foo=notthis&baz=[not,this,either]&bat=false').should == json
+      end
+
+      it "does not die on malformed json" do
+        status('CONTENT_TYPE'=>'application/json', 'rack.input'=>StringIO.new('!@#%(%*!')).should == 400
+      end
+    end
+
+    describe "works with indifferent_params" do
+      before do
+        app(:bare) do
+          plugin :json, :request_body => true
+          plugin :indifferent_params
+
+          route do |r|
+            r.on 'foo' do
+              {foo: params[:foo]}
+            end
+            r.on 'bar/baz/bat' do
+              {bat: params[:bar][params[:baz]][:bat]}
+            end
+          end
+        end
+      end
+
+      it "should indifference parsed bodies" do
+        body('/foo', 'CONTENT_TYPE'=>'application/json', 'rack.input'=>StringIO.new(json)).should == '{"foo":"bar"}'
+      end
+
+      it "should recursively indifference parsed bodies" do
+        body('/bar/baz/bat',
+             'CONTENT_TYPE'=>'application/json',
+             'rack.input'=>StringIO.new({bar:[0,"this",{bat:"self"}],baz:2}.to_json)
+            ).should == '{"bat":"self"}'
+      end
+    end
   end
 end


### PR DESCRIPTION
this is a great framework! we chatted for a bit after rubyconf at karaoke... good talking with you. i finally got some time to play with it, and wanted to try using it for json api type stuff. this PR does:

* new option to json plugin - `:request_body => true`
* if set, request bodies that are json will be parsed and merged into params
* attempts to work with `indifferent_params` plugin
* adds tests / comments for the above

thoughts? i'm not too sure about the `params` integration...