### PR TITLE
Add the symbolized_params plugin

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 = HEAD
 
+* Add symbolized_params plugin, which exposes request params with symbolized keys (janko-m) (#20)
+
 * Add json_parser plugin, for parsing request bodies in JSON format (jeremyevans)
 
 = 2.2.0 (2015-04-13)

--- a/lib/roda/plugins/symbolized_params.rb
+++ b/lib/roda/plugins/symbolized_params.rb
@@ -1,0 +1,60 @@
+class Roda
+  module RodaPlugins
+    # The symbolized_params plugin adds a +params+ instance
+    # method which returns a copy of the request params hash
+    # with symbolized keys.
+    # Example:
+    #
+    #   plugin :symbolized_keys
+    #
+    #   route do |r|
+    #     params[:foo]
+    #   end
+    #
+    # The params hash is initialized lazily, so you only pay
+    # the penalty of copying the request params if you call
+    # the +params+ method.
+    #
+    # This differs from the indifferent_params plugin, which
+    # keeps string keys in +params+, but allows the +Hash#[]+
+    # operator to accept symbols. On the other hand, with the
+    # symbolized_params plugin +params+ has actual symbol
+    # keys, which allows you to use other Hash methods like
+    # +Hash#fetch+ with symbol keys, and use +params+ as
+    # keyword arguments.
+    #
+    # Since Symbol garbage collection was introduced only in
+    # Ruby 2.2.0, using this plugin is *not* recommended if
+    # you're running Ruby version lower than 2.2.0. This is
+    # because prior to 2.2.0 all symbols stay in memory
+    # indefinitely (or until the process is killed), which
+    # can lead to denial of service attacks.
+    module SymbolizedParams
+      module InstanceMethods
+        # A copy of the request params with symbolized keys.
+        def params
+          @_params ||= symbolized_params(request.params)
+        end
+
+        private
+
+        # Recursively process the request params and symbolize
+        # the keys, leaving other values alone.
+        def symbolized_params(params)
+          case params
+          when Hash
+            hash = {}
+            params.each { |k, v| hash[k.to_sym] = symbolized_params(v) }
+            hash
+          when Array
+            params.map { |x| symbolized_params(x) }
+          else
+            params
+          end
+        end
+      end
+    end
+
+    register_plugin(:symbolized_params, SymbolizedParams)
+  end
+end

--- a/spec/plugin/symbolized_params_spec.rb
+++ b/spec/plugin/symbolized_params_spec.rb
@@ -1,0 +1,13 @@
+require File.expand_path("spec_helper", File.dirname(File.dirname(__FILE__)))
+
+describe "symbolized_params plugin" do
+  it "exposes the symbolized version of request params via params method" do
+    app(:symbolized_params) do |r|
+      r.on do
+        params.inspect
+      end
+    end
+
+    body('QUERY_STRING'=>'a=2&b[][c]=3', 'rack.input'=>StringIO.new).should == '{:a=>"2", :b=>[{:c=>"3"}]}'
+  end
+end

--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -86,6 +86,7 @@
     <li><a href="rdoc/classes/Roda/RodaPlugins/ErrorEmail.html">error_email</a>: Adds ability to easily email a notification when an error is raised by the application.</li>
     <li><a href="rdoc/classes/Roda/RodaPlugins/Flash.html">flash</a>: Adds flash handling</a>.</li>
     <li><a href="rdoc/classes/Roda/RodaPlugins/IndifferentParams.html">indifferent_params</a>: Adds params method for indifferent parameters.</li>
+    <li><a href="rdoc/classes/Roda/RodaPlugins/SymbolizedParams.html">symbolized_params</a>: Adds params method for parameters with symbolized keys.</li>
     <li><a href="rdoc/classes/Roda/RodaPlugins/JsonParser.html">json_parser</a>: Parses request bodies in JSON format.</li>
     <li><a href="rdoc/classes/Roda/RodaPlugins/Mailer.html">mailer</a>: Adds support for sending emails using the routing tree.</li>
     <li><a href="rdoc/classes/Roda/RodaPlugins/Middleware.html">middleware</a>: Allows the Roda app to be used as middleware by another app.</li>


### PR DESCRIPTION
This is an alternative plugin to indifferent_params. Using indifferent parameters is always a bit awkward, because it makes you believe you have a Hash with symbolized keys, until you try to use something like `Hash#fetch` or passing the params as keyword arguments. Even though I'm an experienced programmer, it always surprises me that these things don't work.

I noted that this plugin is not recommended for Ruby versions lower than 2.2.0, because only in this version Symbol GC was introduced.