### PR TITLE
Allow the json plugin to accept a serializer

### DIFF
--- a/spec/plugin/json_spec.rb
+++ b/spec/plugin/json_spec.rb
@@ -46,4 +46,9 @@ describe "json plugin" do
     app.route{[1]}
     body.should == '[1]'
   end
+
+  it "should accept custom serializers" do
+    app.plugin :json, serializer: proc { |o| o.inspect }
+    body("/hash").should == '{"a"=>"b"}'
+  end
 end


### PR DESCRIPTION
Currently the only way to override the JSON conversion is to write something
like this:

```rb
class Roda::RodaRequest
  def convert_to_json(object)
    # custom seralization
  end
end
```

So, I thought that instead we could allow the json plugin to accept an additional `:serializer` option:

```rb
plugin :json, serializer: proc { |o| o.to_json(root: true) }
```