### PR TITLE
Add :include_request option for json plugins

### DIFF
--- a/spec/plugin/json_parser_spec.rb
+++ b/spec/plugin/json_parser_spec.rb
@@ -47,4 +47,16 @@ describe "json_parser plugin" do
     end
     body('rack.input'=>StringIO.new("{'a'=>{'b'=>1}}"), 'CONTENT_TYPE'=>'text/json', 'REQUEST_METHOD'=>'POST').should == '1'
   end
+
+  it "supports :include_request option" do
+    app(:bare) do
+      plugin(:json_parser,
+        :include_request => true,
+        :parser => lambda{|s,r| {"request" => "given"}})
+      route do |r|
+        r.params.to_s
+      end
+    end
+    body('rack.input'=>StringIO.new('{}'), 'CONTENT_TYPE'=>'text/json', 'REQUEST_METHOD'=>'POST').should == '{"request"=>"given"}'
+  end
 end

--- a/spec/plugin/json_spec.rb
+++ b/spec/plugin/json_spec.rb
@@ -51,4 +51,12 @@ describe "json plugin" do
     app.plugin :json, :serializer => proc{|o| o.inspect}
     body("/hash").should == '{"a"=>"b"}'
   end
+
+  it "should give serializer the request if :include_request is set" do
+    app.plugin :json,
+      :include_request => true,
+      :serializer => lambda{|o,r| "request given"}
+
+    body("/hash").should == 'request given'
+  end
 end


### PR DESCRIPTION
When using the json plugin, sometimes we want to serialize the object differently depending on the request headers or request parameters. For example, we might want to give the client the ability to specify which post associations they want returned, with a request like /posts?include=author,comments.

If :include_request=>true is passed to the request, the request object will be passed as the second argument when calling the serializer. We add it to the json_parser plugin as well for consistency.