### PR TITLE
Payload plugin

### DIFF
--- a/lib/roda/plugins/payload.rb
+++ b/lib/roda/plugins/payload.rb
@@ -24,8 +24,8 @@ class Roda
         # returned.
         def payload
           @_payload ||=
-            if Roda::RodaPlugins.instance_variable_get(:@plugins)[:json] && defined?(JSON)
-              JSON.parse(raw_payload) rescue raw_payload
+            if opts[:json_parser_parser] && request.media_type =~ /json/
+              opts[:json_parser_parser].call(raw_payload) rescue raw_payload
             else
               raw_payload
             end

--- a/lib/roda/plugins/payload.rb
+++ b/lib/roda/plugins/payload.rb
@@ -1,0 +1,31 @@
+class Roda
+  module RodaPlugins
+    # The payload plugin adds a +payload+ instance
+    # method which returns a copy of the payload data (as a String)
+    # if it is available. Useful when such data is being sent
+    # via a GET request or non-POST request.
+    # Example:
+    #
+    #   plugin :indifferent_params
+    #
+    #   route do |r|
+    #     payload
+    #   end
+    #
+    # The payload String is initialized lazily, so you only pay
+    # the penalty of copying the request params if you call
+    # the +payload+ method.
+    module Payload
+      module InstanceMethods
+        # A copy of the payload
+        def payload
+          @_payload ||= request.env['rack.input'].read
+        rescue
+          nil
+        end
+      end  
+    end
+
+    register_plugin(:payload, Payload)
+  end
+end

--- a/lib/roda/plugins/payload.rb
+++ b/lib/roda/plugins/payload.rb
@@ -17,9 +17,25 @@ class Roda
     # the +payload+ method.
     module Payload
       module InstanceMethods
-        # A copy of the payload
+        # Attempts to parse JSON if the `Roda::RodaPlugins::Json` plugin
+        # is loaded, and the payload is parsable JSON. If the payload
+        # is not parsable JSON it will fall back to the raw String content.
+        # If the JSON Plugin is not loaded, the raw String content will be
+        # returned.
         def payload
-          @_payload ||= request.env['rack.input'].read
+          @_payload ||=
+            if Roda::RodaPlugins.instance_variable_get(:@plugins)[:json] && defined?(JSON)
+              JSON.parse(raw_payload) rescue raw_payload
+            else
+              raw_payload
+            end
+        end
+
+        private
+
+        # Reads the payload data to a String if it exists in `request.env`
+        def raw_payload
+          @_raw_payload ||= request.env['rack.input'].read
         rescue
           nil
         end

--- a/lib/roda/plugins/payload.rb
+++ b/lib/roda/plugins/payload.rb
@@ -35,9 +35,7 @@ class Roda
 
         # Reads the payload data to a String if it exists in `request.env`
         def raw_payload
-          @_raw_payload ||= request.env['rack.input'].read
-        rescue
-          nil
+          @_raw_payload ||= env['rack.input'].read
         end
       end  
     end

--- a/lib/roda/plugins/payload.rb
+++ b/lib/roda/plugins/payload.rb
@@ -6,7 +6,7 @@ class Roda
     # via a GET request or non-POST request.
     # Example:
     #
-    #   plugin :indifferent_params
+    #   plugin :payload
     #
     #   route do |r|
     #     payload

--- a/spec/plugin/payload_spec.rb
+++ b/spec/plugin/payload_spec.rb
@@ -13,4 +13,34 @@ describe "payload plugin" do
 
     body('QUERY_STRING'=>'a=2&b=3', 'rack.input'=>StringIO.new(string)).must_equal string
   end
+
+  describe "`Roda::RodaPlugins::Json` plugin is loaded" do
+    before { Roda::RodaPlugins.load_plugin(:json) }
+
+    describe "payload IS in JSON format" do
+      let(:json_string) { JSON.dump({'key' => string}) }
+
+      it "should parse the JSON and return the parsed object" do
+        app(:payload) do |r|
+          r.on do
+            payload['key']
+          end
+        end
+
+        body('QUERY_STRING'=>'a=2', 'rack.input'=>StringIO.new(json_string)).must_equal string
+      end
+    end
+
+    describe "payload IS NOT in JSON format" do
+      it "should just return the raw String contents" do
+        app(:payload) do |r|
+          r.on do
+            payload
+          end
+        end
+
+        body('QUERY_STRING'=>'a=2', 'rack.input'=>StringIO.new(string)).must_equal string
+      end
+    end
+  end
 end

--- a/spec/plugin/payload_spec.rb
+++ b/spec/plugin/payload_spec.rb
@@ -26,32 +26,32 @@ describe "payload plugin" do
     end
   end
 
-  describe "`Roda::RodaPlugins::Json` plugin is loaded" do
-    before { Roda::RodaPlugins.load_plugin(:json) }
+  describe "`Roda::RodaPlugins::Json` plugin is loaded on the app" do
+    before do
+      app(:bare) do |r|
+        plugin :payload
+        plugin :json_parser
 
-    describe "payload IS in JSON format" do
-      let(:json_string) { JSON.dump({'key' => string}) }
-
-      it "should parse the JSON and return the parsed object" do
-        app(:payload) do |r|
+        route do |r|
           r.on do
-            payload['key']
+            payload.to_s
           end
         end
-
-        body('QUERY_STRING'=>'a=2', 'rack.input'=>StringIO.new(json_string), 'CONTENT_TYPE'=>'text/json').must_equal string
       end
     end
 
-    describe "payload IS NOT in JSON format" do
-      it "should just return the raw String contents" do
-        app(:payload) do |r|
-          r.on do
-            payload
-          end
-        end
+    describe "payload IS in JSON format" do
+      let(:obj) { {'key' => string} }
+      let(:json_string) { JSON.dump(obj) }
 
-        body('QUERY_STRING'=>'a=2', 'rack.input'=>StringIO.new(string)).must_equal string
+      it "should parse the JSON and return the parsed object" do
+        body('QUERY_STRING'=>'a=2', 'rack.input'=>StringIO.new(json_string), 'CONTENT_TYPE'=>'text/json').must_equal obj.to_s
+      end
+    end
+
+    describe "payload IS NOT in JSON format (but content_type mistakenly says it is)" do
+      it "should just return the raw String contents" do
+        body('QUERY_STRING'=>'a=2', 'rack.input'=>StringIO.new(string), 'CONTENT_TYPE'=>'text/json').must_equal string
       end
     end
   end

--- a/spec/plugin/payload_spec.rb
+++ b/spec/plugin/payload_spec.rb
@@ -1,0 +1,16 @@
+require File.expand_path("spec_helper", File.dirname(File.dirname(__FILE__)))
+
+describe "payload plugin" do
+  # random 5 character String
+  let(:string) { (0...5).map { (65 + rand(26)).chr }.join }
+
+  it "Reads the contents of the `rack.input` object and returns it" do
+    app(:payload) do |r|
+      r.on do
+        payload
+      end
+    end
+
+    body('QUERY_STRING'=>'a=2&b=3', 'rack.input'=>StringIO.new(string)).must_equal string
+  end
+end

--- a/spec/plugin/payload_spec.rb
+++ b/spec/plugin/payload_spec.rb
@@ -14,6 +14,18 @@ describe "payload plugin" do
     body('QUERY_STRING'=>'a=2&b=3', 'rack.input'=>StringIO.new(string)).must_equal string
   end
 
+  describe "No payload content" do
+    it "returns `nil` and doesn't raise an error" do
+      app(:payload) do |r|
+        r.on do
+          payload
+        end
+      end
+
+      body('QUERY_STRING'=>'a=2&b=3').must_equal ''
+    end
+  end
+
   describe "`Roda::RodaPlugins::Json` plugin is loaded" do
     before { Roda::RodaPlugins.load_plugin(:json) }
 

--- a/spec/plugin/payload_spec.rb
+++ b/spec/plugin/payload_spec.rb
@@ -22,7 +22,7 @@ describe "payload plugin" do
         end
       end
 
-      body('QUERY_STRING'=>'a=2&b=3').must_equal ''
+      body('QUERY_STRING'=>'a=2&b=3', 'rack.input'=>StringIO.new).must_equal ''
     end
   end
 
@@ -39,7 +39,7 @@ describe "payload plugin" do
           end
         end
 
-        body('QUERY_STRING'=>'a=2', 'rack.input'=>StringIO.new(json_string)).must_equal string
+        body('QUERY_STRING'=>'a=2', 'rack.input'=>StringIO.new(json_string), 'CONTENT_TYPE'=>'text/json').must_equal string
       end
     end
 


### PR DESCRIPTION
I was working on a project today where one of the requests I wanted to handle expected to receive a `JSON` String in it's payload and was surprised to see the docs makes no mention of how to access the payload (and there is no plugin out of the box).  I created this little plugin to read and return the payload content in a lazily-loaded method to make it easier to access this information.