### PR TITLE
Fixed render plugin to explicitly require erubis and erb for tilt

### DIFF
--- a/lib/roda/plugins/render.rb
+++ b/lib/roda/plugins/render.rb
@@ -1,4 +1,6 @@
-require "tilt"
+require 'erb'
+require 'tilt'
+require 'tilt/erubis'
 
 class Roda
   module RodaPlugins


### PR DESCRIPTION
While beginning a new project with erb templates I found that the current version of tilt requires explicit declaration of erb(because of stdlib inclusion) and tilt/erubis for thread safety..