### PR TITLE
allow passing a block to multi_run plugin

### DIFF
--- a/lib/roda/plugins/multi_run.rb
+++ b/lib/roda/plugins/multi_run.rb
@@ -25,6 +25,14 @@ class Roda
     # starting with +/ro+ to +OtherRodaApp+, and routes starting with +/si+ to
     # SinatraApp.
     #
+    # Optionally you can pass a block to +multi_run+ that gets called with prefix.
+    #
+    #   App.route do |r|
+    #     r.multi_run do |prefix\
+    #       # do something based on prefix before the request is passed further
+    #     end
+    #   end
+    #
     # The multi_run plugin is similar to the multi_route plugin, with the difference
     # being the multi_route plugin keeps all routing subtrees in the same Roda app/class,
     # while multi_run dispatches to other rack apps.  If you want to isolate your routing
@@ -76,6 +84,7 @@ class Roda
         # dispatch the request to the stored rack application.
         def multi_run
           on self.class.multi_run_regexp do |prefix|
+            yield prefix if block_given?
             run scope.class.multi_run_apps[prefix]
           end
         end

--- a/spec/plugin/multi_run_spec.rb
+++ b/spec/plugin/multi_run_spec.rb
@@ -69,4 +69,19 @@ describe "multi_run plugin" do
     @app = a
     body("/b").must_equal 'b2'
   end
+
+  it "yields prefix" do
+    yielded = false
+
+    app(:multi_run) do |r|
+      r.multi_run do |prefix|
+        yielded = prefix
+      end
+    end
+
+    app.run "a", Class.new(Roda).class_eval{route{"a1"}; app}
+
+    body("/a").must_equal "a1"
+    yielded.must_equal "a"
+  end
 end


### PR DESCRIPTION
So it yields with prefix before calling run.

I use it for adding variables to env that gets passed.