### PR TITLE
Make middleware plugin compatible with multi_route

### DIFF
--- a/lib/roda/plugins/middleware.rb
+++ b/lib/roda/plugins/middleware.rb
@@ -74,7 +74,7 @@ class Roda
 
         # Override the route block so that if no route matches, we throw so
         # that the next middleware is called.
-        def route(&block)
+        def route(*args, &block)
           super do |r|
             res = instance_exec(r, &block)
             throw :next, true if r.forward_next

--- a/spec/plugin/middleware_spec.rb
+++ b/spec/plugin/middleware_spec.rb
@@ -56,4 +56,23 @@ describe "middleware plugin" do
     end
     body.must_equal 'a'
   end
+
+  it "is compatible with the multi_route plugin" do
+    app(:bare) do
+      plugin :multi_route
+      plugin :middleware
+
+      route("a") do |r|
+        r.is "b" do
+          "ab"
+        end
+      end
+
+      route do |r|
+        r.multi_route
+      end
+    end
+
+    body('/a/b').must_equal 'ab'
+  end
 end


### PR DESCRIPTION
The "multi_route" plugin overrides Roda.route and allows it to take arguments. If the "middleware" plugin is loaded after "multi_route", it currently overrides Roda.route with no arguments again. This change allows Roda.route to take any number of arguments, keeping these two plugins compatible.