### PR TITLE
Fix a syntax error in an example comment

### DIFF
--- a/lib/roda/plugins/path.rb
+++ b/lib/roda/plugins/path.rb
@@ -19,7 +19,7 @@ class Roda
     #   path Baz do |baz, *paths|
     #     "/baz/#{baz.id}/#{paths.join('/')}"
     #   end
-    #   path Quux |quux, path|
+    #   path Quux do |quux, path|
     #     "/quux/#{quux.id}/#{path}"
     #   end
     #


### PR DESCRIPTION
I think this should fix the syntax highlighting.