### PR TITLE
Fix an error in the "caching" plugin example

### DIFF
--- a/lib/roda/plugins/caching.rb
+++ b/lib/roda/plugins/caching.rb
@@ -5,7 +5,7 @@ class Roda
     # For proper caching, you should use either the +last_modified+ or
     # +etag+ request methods.  
     #
-    #   r.get '/albums/:d' do |album_id|
+    #   r.get 'albums/:d' do |album_id|
     #     @album = Album[album_id]
     #     r.last_modified @album.updated_at
     #     view('album')
@@ -13,7 +13,7 @@ class Roda
     #
     #   # or
     #
-    #   r.get '/albums/:d' do |album_id|
+    #   r.get 'albums/:d' do |album_id|
     #     @album = Album[album_id]
     #     r.etag @album.sha1
     #     view('album')


### PR DESCRIPTION
Roda doesn't support prepending path string with "/".