### PR TITLE
Allow passing a block to rewrite_path plugin for dynamic replacements.

### DIFF
--- a/lib/roda/plugins/path_rewriter.rb
+++ b/lib/roda/plugins/path_rewriter.rb
@@ -83,20 +83,23 @@ class Roda
         # Rewrite remaining_path and/or PATH_INFO based on the path rewrites.
         def initialize(scope, env)
           path_info = env[PATH_INFO]
-          rewrite = ->(type, what) do
-            scope.class.opts[type].each do |was, is|
-              if is.is_a? Proc
-                what.sub!(was) { is.call(Regexp.last_match) }
-              else
-                what.sub!(was, is)
-              end
-            end
-          end
 
-          rewrite.call(:path_info_rewrites, path_info)
+          rewrite(scope.class.opts[:path_info_rewrites], path_info)
           super
           remaining_path = @remaining_path = @remaining_path.dup
-          rewrite.call(:remaining_path_rewrites, remaining_path)
+          rewrite(scope.class.opts[:remaining_path_rewrites], remaining_path)
+        end
+
+        private
+
+        def rewrite(replacements, path)
+          replacements.each do |was, is|
+            if is.is_a? Proc
+              path.sub!(was) { is.call(Regexp.last_match) }
+            else
+              path.sub!(was, is)
+            end
+          end
         end
       end
     end

--- a/spec/plugin/path_rewriter_spec.rb
+++ b/spec/plugin/path_rewriter_spec.rb
@@ -11,6 +11,10 @@ describe "path_rewriter plugin" do
       rewrite_path '/3', '/h'
       rewrite_path '/3', '/g', :path_info=>true
       rewrite_path(/\A\/e\z/, '/f')
+      rewrite_path(/\A\/(dynamic1)/) { |match| "/#{match[1].capitalize}" }
+      rewrite_path(/\A\/(dynamic2)/, :path_info=>true) { |match| "/#{match[1].capitalize}" }
+      proc { rewrite_path('/a', '/z') { |match| "/x" } }.must_raise(ArgumentError)
+
       route do |r|
         "#{r.path_info}:#{r.remaining_path}"
       end
@@ -29,7 +33,9 @@ describe "path_rewriter plugin" do
     body('/2').must_equal '/1:/b'
     body('/2/f').must_equal '/1/f:/b/f'
     body('/3').must_equal '/g:/g'
-    
+    body('/dynamic1').must_equal '/dynamic1:/Dynamic1'
+    body('/dynamic2').must_equal '/Dynamic2:/Dynamic2'
+
     app.freeze
     body('/a').must_equal '/a:/b'
     proc{app.rewrite_path '/a', '/b'}.must_raise


### PR DESCRIPTION
Enhancement for the rewrite_path plugin to enable things like:

    rewrite_path %r{\A/foo/(\w+)} {|match| "/foo/#{match[1].downcase}" }
    # /foo/BAR => /foo/bar