### PR TITLE
ContentFor: Support HAML

### DIFF
--- a/spec/plugin/content_for_spec.rb
+++ b/spec/plugin/content_for_spec.rb
@@ -2,32 +2,56 @@ require File.expand_path("spec_helper", File.dirname(File.dirname(__FILE__)))
 
 begin
   require 'tilt/erb'
+  require 'tilt/haml'
 rescue LoadError
-  warn "tilt not installed, skipping content_for plugin test"  
+  warn "tilt not installed, skipping content_for plugin test"
 else
-describe "content_for plugin" do
-  before do
-    app(:bare) do
-      plugin :render, :views=>'./spec/views'
-      plugin :content_for
+  describe "content_for plugin" do
+    describe "defaulting to erb engine" do
+      before do
+        app(:bare) do
+          plugin :render, :views => './spec/views'
+          plugin :content_for
 
-      route do |r|
-        r.root do
-          view(:inline=>"<% content_for :foo do %>foo<% end %>bar", :layout=>{:inline=>'<%= yield %> <%= content_for(:foo) %>'})
-        end
-        r.get 'a' do
-          view(:inline=>"bar", :layout=>{:inline=>'<%= content_for(:foo) %> <%= yield %>'})
+          route do |r|
+            r.root do
+              view(:inline => "<% content_for :foo do %>foo<% end %>bar", :layout => { :inline => '<%= yield %> <%= content_for(:foo) %>' })
+            end
+            r.get 'a' do
+              view(:inline => "bar", :layout => { :inline => '<%= content_for(:foo) %> <%= yield %>' })
+            end
+          end
         end
       end
+
+      it "should be able to set content in template and get that content in the layout" do
+        body.strip.must_equal "bar foo"
+      end
+
+      it "should work if content is not set by the template" do
+        body('/a').strip.must_equal "bar"
+      end
+    end
+
+
+    describe "with explicit haml engine" do
+      before do
+        app(:bare) do
+          plugin :render, :engine => 'haml'
+          plugin :content_for
+
+          route do |r|
+            r.root do
+              view(:inline => "- content_for :foo do\n  - capture_haml do\n    foo\nbar", :layout => { :inline => "= yield\n=content_for :foo" })
+            end
+          end
+        end
+      end
+
+      it "should work with alternate rendering engines" do
+        body.strip.must_equal "bar\nfoo"
+      end
+
     end
   end
-
-  it "should be able to set content in template and get that content in the layout" do
-    body.strip.must_equal "bar foo"
-  end
-
-  it "should work if content is not set by the template" do
-    body('/a').strip.must_equal "bar"
-  end
-end
 end


### PR DESCRIPTION
add haml (and maybe others) support for `content_for`. Takes advantage of `content_for`'s dependency on the Render plugin for rendering subsets of views.