### PR TITLE
Alias #<< to #write for streaming IO compatibility

### DIFF
--- a/lib/roda/plugins/streaming.rb
+++ b/lib/roda/plugins/streaming.rb
@@ -100,9 +100,14 @@ class Roda
         end
 
         # Add output to the streaming response body.
-        def <<(data)
+        def write(data)
           @scheduler.schedule{@front.call(data.to_s)}
           self
+        end
+
+        # Alias for +write+.
+        def <<(data)
+          write(data)
         end
 
         # Add the given block as a callback to call when the block closes.


### PR DESCRIPTION
The standard convention of writable streams is that they respond to `#write`. If we make the stream object respond to `#write`, we could for example use `IO.copy_stream` to efficiently copy a stream to it.

```rb
stream do |out|
  IO.copy_stream(StringIO.new(content), out)
end
```