### PR TITLE
Add symbol_status plugin for symbolic status names in response.status=

### DIFF
--- a/lib/roda/plugins/symbol_status.rb
+++ b/lib/roda/plugins/symbol_status.rb
@@ -1,0 +1,30 @@
+# frozen-string-literal: true
+
+class Roda
+  module RodaPlugins
+    # The symbol_status plugin patches the +status=+ response method to
+    # accept the status name as a symbol.  If given an integer value,
+    # the default behaviour is used.
+    #
+    # Examples:
+    #   r.is "needs_authorization"
+    #     response.code = :unauthorized
+    #   end
+    #   r.is "nothing"
+    #     response.code = :no_content
+    #   end
+    #
+    # The conversion is done through <tt>Rack::Utils.status_code</tt>.
+    module SymbolStatus
+      module ResponseMethods
+        # Sets the response status code by fixnum or symbol name
+        def status=(code)
+          code = Rack::Utils.status_code(code) if code.is_a? Symbol
+          super(code)
+        end
+      end
+    end
+
+    register_plugin(:symbol_status, SymbolStatus)
+  end
+end

--- a/spec/plugin/symbol_status_spec.rb
+++ b/spec/plugin/symbol_status_spec.rb
@@ -1,0 +1,23 @@
+require File.expand_path("spec_helper", File.dirname(File.dirname(__FILE__)))
+
+describe "symbol_status plugin" do
+  it "accepts a symbol" do
+    app(:symbol_status) do |r|
+      r.on do
+        response.status = :unauthorized
+      end
+    end
+
+    status.must_equal 401
+  end
+
+  it "accepts a fixnum" do
+    app(:symbol_status) do |r|
+      r.on do
+        response.status = 204
+      end
+    end
+
+    status.must_equal 204
+  end
+end


### PR DESCRIPTION
This plugin enables response.status= to turn a status name like :ok
into its corresponding HTTP status code.  The behaviour of the method
when being passed a status code as integer is left unchanged.