### PR TITLE
rack seems to be adding "HTTP_" to all the headers

### DIFF
--- a/lib/roda/plugins/header_matchers.rb
+++ b/lib/roda/plugins/header_matchers.rb
@@ -54,7 +54,7 @@ class Roda
 
         # Match if the given uppercase key is present inside the environment.
         def match_header(key)
-          if v = @env[key.upcase.tr("-","_")]
+          if v = @env["HTTP_" + key.upcase.tr("-","_")]
             @captures << v
           end
         end


### PR DESCRIPTION
for plugin :header_matchers used like this to just return the value of the header



```ruby
route do |r|
  r.on header: 'x-api-version' do |header_value|
    header_value
  end
end
```

I couldn't get it to match with the default setup, not sure if this is the way to go about fixing it?

Gemfile.lock
```
GEM
  remote: https://rubygems.org/
  specs:
    coderay (1.1.1)
    method_source (0.8.2)
    mini_portile2 (2.1.0)
    pry (0.10.3)
      coderay (~> 1.1.0)
      method_source (~> 0.8.1)
      slop (~> 3.4)
    puma (3.4.0)
    rack (1.6.4)
    rake (11.1.2)
    require_all (1.3.3)
    roda (2.14.0)
      rack
    sequel (4.34.0)
    slop (3.6.0)
    tiny_tds (1.0.4)
      mini_portile2 (~> 2.0)

PLATFORMS
  ruby

DEPENDENCIES
  pry
  puma
  rake
  require_all
  roda
  sequel
  tiny_tds

BUNDLED WITH
   1.11.2
```