### PR TITLE
Update MRI cache comments in per_thread_caching plugin

### DIFF
--- a/lib/roda/plugins/per_thread_caching.rb
+++ b/lib/roda/plugins/per_thread_caching.rb
@@ -6,13 +6,9 @@ class Roda
     # The per_thread_caching plugin changes the default cache
     # from being a shared thread safe cache to a separate cache per
     # thread.  This means getting or setting values no longer
-    # needs a mutex on non-MRI ruby implementations, which may be
-    # faster when using a thread pool.  However, since the caches
-    # are no longer shared, this will take up more memory.
-    #
-    # Note that it does not make sense to use this plugin on MRI,
-    # since the default cache on MRI doesn't use a mutex as it
-    # is already thread safe due to the GVL.
+    # needs a mutex, which may be faster when using a thread pool.
+    # However, since the caches are no longer shared, this will
+    # take up more memory.
     #
     # Using this plugin changes the matcher regexp cache to use
     # per-thread caches, and changes the default for future


### PR DESCRIPTION
Removes references to the MRI default cache not using a Mutex, since it does now with the 89b9caf commit.