### PR TITLE
Add a note about second argument to r.redirect

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -133,6 +133,8 @@ it will be interpreted as the body for the response.
 
 +r.redirect+ immediately returns the response,
 allowing for code such as <tt>r.redirect(path) if some_condition</tt>.
+If +r.redirect+ is called with two arguments, the second argument is used as
+the HTTP status (defaults to 302).
 If +r.redirect+ is called without arguments
 and the current request method is not +GET+, it redirects to the current path.
 


### PR DESCRIPTION
Couldn't see any mention about setting the HTTP status code to redirects in the readme, which was the first place I looked for it, so thought this might be helpful to add.