### PR TITLE
type_routing plugin breaks public plugin

### DIFF
--- a/lib/roda.rb
+++ b/lib/roda.rb
@@ -509,6 +509,12 @@ class Roda
         # The current path to match requests against.
         attr_reader :remaining_path
 
+        # An alias of remaining_path. If a plugin changes remaining_path then
+        # it should override this method to return the untouched original.
+        def real_remaining_path
+          remaining_path
+        end
+
         # Match POST requests.  If no arguments are provided, matches all POST
         # requests, otherwise, matches only POST requests where the arguments
         # given fully consume the path.

--- a/lib/roda/plugins/public.rb
+++ b/lib/roda/plugins/public.rb
@@ -41,7 +41,7 @@ class Roda
         # Serve files from the public directory if the file exists and this is a GET request.
         def public
           if is_get?
-            path = PARSER.unescape(remaining_path)
+            path = PARSER.unescape(real_remaining_path)
             return if path.include?(NULL_BYTE)
 
             roda_opts = roda_class.opts

--- a/lib/roda/plugins/type_routing.rb
+++ b/lib/roda/plugins/type_routing.rb
@@ -169,6 +169,16 @@ class Roda
           super
         end
 
+        # Return the untouched original remaining_path if we
+        # have modified it.
+        def real_remaining_path
+          if defined?(@type_routing_extension)
+            remaining_path + ".#{@type_routing_extension}"
+          else
+            super
+          end
+        end
+
         private
 
         # Removes a trailing file extension from the path, and sets

--- a/spec/plugin/type_routing_spec.rb
+++ b/spec/plugin/type_routing_spec.rb
@@ -264,4 +264,32 @@ describe "type_routing plugin" do
     body('/a.html').must_equal 'HTML'
     body('/a.json').must_equal 'JSON'
   end
+
+  it "removes the handled part from r.remaining_path" do
+    app(:bare) do
+      plugin :type_routing
+
+      route do |r|
+        r.is 'a' do
+          r.html{ r.remaining_path }
+        end
+      end
+    end
+
+    body('/a.html').must_equal ''
+  end
+
+  it "overrides r.real_remaining_path correctly" do
+    app(:bare) do
+      plugin :type_routing
+
+      route do |r|
+        r.is 'a' do
+          r.html{ r.real_remaining_path }
+        end
+      end
+    end
+
+    body('/a.html').must_equal '.html'
+  end
 end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -12,6 +12,18 @@ describe "request.path, .remaining_path, and .matched_path" do
   end
 end
 
+describe "request.real_remaining_path" do
+  it "should be an alias of remaining_path" do
+    app do |r|
+      r.on "foo" do
+        "#{r.remaining_path}:#{r.real_remaining_path}"
+      end
+    end
+
+    body("/foo/bar").must_equal "/bar:/bar"
+  end
+end
+
 describe "request.halt" do
   it "should return rack response as argument given it as argument" do
     app do |r|


### PR DESCRIPTION
It seems that the type_routing plugin can break the public plugin if the former has a file type defined which we later ask the public plugin to serve. 

With the following app:

```ruby
require 'roda'

class App < Roda

  plugin :type_routing, :types => { :png => 'image/png' }
  plugin :public

  route do |r|
    r.public
  end
  
end

run App
```

Assuming that `public/test.png` exists, a 404 is returned. This seems to be because the public plugin is using `remaining_path` and the type_routing plugin has changed it (removed the .png extension). This probably isn't the intended behaviour?