### PR TITLE
Remove Content-Type and Content-Length headers on 204/205/304 responses.

### DIFF
--- a/lib/roda.rb
+++ b/lib/roda.rb
@@ -867,6 +867,7 @@ class Roda
       # Instance methods for RodaResponse
       module ResponseMethods
         CONTENT_LENGTH = "Content-Length".freeze
+        CONTENT_TYPE = "Content-Type".freeze
         DEFAULT_HEADERS = {"Content-Type" => "text/html".freeze}.freeze
         LOCATION = "Location".freeze
 
@@ -936,6 +937,10 @@ class Roda
           set_default_headers
           h = @headers
           h[CONTENT_LENGTH] ||= @length.to_s
+          if b.empty? && ((s >= 100 && s <= 199) || [204, 205, 304].include?(s))
+            h.delete(CONTENT_LENGTH)
+            h.delete(CONTENT_TYPE)
+          end
           [s, h, b]
         end
 

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -65,6 +65,16 @@ describe "response #finish" do
     header('Content-Length').must_equal '1'
   end
 
+  it "should not set Content-Type header on a 204 response" do
+    app do |r|
+      response.status = 204
+      throw :halt, response.finish
+    end
+
+    header('Content-Type').must_equal nil
+    header('Content-Length').must_equal nil
+  end
+
   it "should not overwrite existing status" do
     app do |r|
       response.status = 500


### PR DESCRIPTION
Fixes #101.