### PR TITLE
Use STATUS_WITH_NO_ENTITY_BODY in finish instead of hardcoded ints.

### DIFF
--- a/lib/roda.rb
+++ b/lib/roda.rb
@@ -936,7 +936,7 @@ class Roda
           s = (@status ||= b.empty? ? 404 : default_status)
           set_default_headers
           h = @headers
-          if b.empty? && ((s >= 100 && s <= 199) || s == 204 || s == 205 || s == 304)
+          if b.empty? && Rack::Utils::STATUS_WITH_NO_ENTITY_BODY.include?(s)
             h.delete(CONTENT_TYPE)
           else
             h[CONTENT_LENGTH] ||= @length.to_s


### PR DESCRIPTION
Rack::Utils has a Set available with this list of integers in, and checking a Set for inclusion should be faster than all the comparisons.

Just an exploratory PR really to see what you think :)

I did also wonder whether it was worth `dup`ing and `freeze`ing it to a local constant?