### PR TITLE
Swap 'gem' method for 'require'

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ end
 
 require "roda"
 require "stringio"
-gem 'minitest'
+require "minitest"
 require "minitest/autorun"
 
 #def (Roda::RodaPlugins).warn(s); end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 $:.unshift(File.expand_path("../lib", File.dirname(__FILE__)))
-
+gem 'minitest'
 require "rubygems"
 
 if ENV['WARNING']
@@ -26,7 +26,6 @@ end
 
 require "roda"
 require "stringio"
-require "minitest"
 require "minitest/autorun"
 
 #def (Roda::RodaPlugins).warn(s); end
@@ -58,7 +57,7 @@ class Minitest::Spec
     env = {"REQUEST_METHOD" => "GET", "PATH_INFO" => "/", "SCRIPT_NAME" => ""}.merge(env)
     @app.call(env)
   end
-  
+
   def status(path='/', env={})
     req(path, env)[0]
   end


### PR DESCRIPTION
[Docs](https://ruby-doc.org/stdlib-2.4.1/libdoc/rubygems/rdoc/Kernel.html#method-i-gem) say:

1) If you will be activating the latest version of a gem, there is no need to call #gem, Kernel#require will do the right thing for you.
2) #gem should be called before any require statements (otherwise RubyGems may load a conflicting library version).

So there are two reasons to use 'require' instead of 'gem'. Or am I missing something?