### PR TITLE
Handle extensions containing dots in type_routing

### DIFF
--- a/lib/roda/plugins/type_routing.rb
+++ b/lib/roda/plugins/type_routing.rb
@@ -130,7 +130,7 @@ class Roda
         mimes.freeze
 
         type_keys = config[:types].keys
-        config[:extension_regexp] = /(.+)\.(#{Regexp.union(type_keys.map(&:to_s))})\z/
+        config[:extension_regexp] = /(.+?)\.(#{Regexp.union(type_keys.map(&:to_s))})\z/
 
         type_keys.each do |type|
           app::RodaRequest.send(:define_method, type) do |&block|

--- a/spec/plugin/type_routing_spec.rb
+++ b/spec/plugin/type_routing_spec.rb
@@ -292,4 +292,23 @@ describe "type_routing plugin" do
 
     body('/a.html').must_equal '.html'
   end
+
+  it "takes the longest file extension first, when ambiguous" do
+    app(:bare) do
+      plugin :type_routing, :types => {
+        :gz => 'application/octet-stream',
+        :'tar.gz' => 'application/octet-stream',
+      }
+
+      route do |r|
+        r.is 'a' do
+          r.on_type(:gz) { 'GZ' }
+          r.on_type(:'tar.gz') { 'TAR.GZ' }
+          raise "Mismatch!"
+        end
+      end
+    end
+
+    body('/a.tar.gz').must_equal 'TAR.GZ'
+  end
 end


### PR DESCRIPTION
I recently ran into a limitation of the type_routing plugin. I was trying to match both ".xml" and ".whatever.xml" as different types, but the ".whatever.xml" type could never be reached.
The commit message below explains the fix. Let me know if you have any questions/comments/feedback.

---

The type_routing plugin previously wouldn't handle extensions containing
the period character. For example, in this app:

    class ExampleApp < Roda
      plugin :type_routing, types: {
        :gz => 'application/octet-stream',
        :'tar.gz' => 'application/octet-stream',
      }
    end

URLs ending in ".tar.gz" would always be detected as the "gz" type,
never the "tar.gz" type.

The commit changes the regex that matches the URL. The group that
captures the "basename" was greedy (by default), meaning that it would capture
`["whatever.tar", "gz"]`. Adding the '?' changes the capture group to be
lazy, so it will now capture `["whatever", "tar.gz"]` instead.