### PR TITLE
Skip configuring the CSRF middleware for csrf plugin

### DIFF
--- a/lib/roda/plugins/csrf.rb
+++ b/lib/roda/plugins/csrf.rb
@@ -10,6 +10,11 @@ class Roda
     #
     #   plugin :csrf, :raise=>true
     #
+    # Optionally you can choose not to setup rack_csrf middleware on the
+    # roda app if you already have one configured:
+    #
+    #   plugin :csrf, :skip_middleware=>true
+    #
     # This adds the following instance methods:
     #
     # csrf_field :: The field name to use for the hidden/meta csrf tag.
@@ -26,6 +31,7 @@ class Roda
 
       # Load the Rack::Csrf middleware into the app with the given options.
       def self.configure(app, opts={})
+        return if opts[:skip_middleware]
         app.instance_exec do
           @middleware.each do |(mid, *rest), _|
             if mid.equal?(CSRF)

--- a/spec/plugin/csrf_spec.rb
+++ b/spec/plugin/csrf_spec.rb
@@ -3,9 +3,9 @@ require File.expand_path("spec_helper", File.dirname(File.dirname(__FILE__)))
 begin
   require 'rack/csrf'
 rescue LoadError
-  warn "rack_csrf not installed, skipping csrf plugin test"  
+  warn "rack_csrf not installed, skipping csrf plugin test"
 else
-describe "csrf plugin" do 
+describe "csrf plugin" do
   it "adds csrf protection and csrf helper methods" do
     app(:bare) do
       use Rack::Session::Cookie, :secret=>'1'
@@ -47,6 +47,62 @@ describe "csrf plugin" do
 
     app.plugin :csrf
     body('/foo', 'REQUEST_METHOD'=>'POST', 'rack.input'=>io).must_equal 'bar'
+  end
+
+  it "can optionally skip setting up the middleware" do
+    sub_app = Class.new(Roda) do
+      plugin :csrf, :skip_middleware=>true
+
+      route do |r|
+        r.get do
+          response['TAG'] = csrf_tag
+          response['METATAG'] = csrf_metatag
+          response['TOKEN'] = csrf_token
+          response['FIELD'] = csrf_field
+          response['HEADER'] = csrf_header
+          'g'
+        end
+        r.post 'bar' do
+          'foobar'
+        end
+        r.post do
+          'p'
+        end
+      end
+    end
+
+    app(:bare) do
+      use Rack::Session::Cookie, :secret=>'1'
+      plugin :csrf, :skip=>['POST:/foo/bar']
+
+      route do |r|
+        r.on 'foo' do
+          r.run sub_app
+        end
+      end
+    end
+
+    io = StringIO.new
+    status('/foo', 'REQUEST_METHOD'=>'POST', 'rack.input'=>io).must_equal 403
+    body('/foo/bar', 'REQUEST_METHOD'=>'POST', 'rack.input'=>io).must_equal 'foobar'
+
+    env = proc{|h| h['Set-Cookie'] ? {'HTTP_COOKIE'=>h['Set-Cookie'].sub("; path=/; HttpOnly", '')} : {}}
+    s, h, b = req('/foo')
+    s.must_equal 200
+    field = h['FIELD']
+    token = Regexp.escape(h['TOKEN'])
+    h['TAG'].must_match(/\A<input type="hidden" name="#{field}" value="#{token}" \/>\z/)
+    h['METATAG'].must_match(/\A<meta name="#{field}" content="#{token}" \/>\z/)
+    b.must_equal ['g']
+    s, _, b = req('/foo', env[h].merge('REQUEST_METHOD'=>'POST', 'rack.input'=>io, "HTTP_#{h['HEADER']}"=>h['TOKEN']))
+    s.must_equal 200
+    b.must_equal ['p']
+
+    sub_app.plugin :csrf, :skip_middleware=>true
+    body('/foo/bar', 'REQUEST_METHOD'=>'POST', 'rack.input'=>io).must_equal 'foobar'
+
+    m = sub_app.instance_variable_get(:@middleware)
+    m.must_equal []
   end
 end
 end

--- a/spec/plugin/csrf_spec.rb
+++ b/spec/plugin/csrf_spec.rb
@@ -3,9 +3,9 @@ require File.expand_path("spec_helper", File.dirname(File.dirname(__FILE__)))
 begin
   require 'rack/csrf'
 rescue LoadError
-  warn "rack_csrf not installed, skipping csrf plugin test"
+  warn "rack_csrf not installed, skipping csrf plugin test"  
 else
-describe "csrf plugin" do
+describe "csrf plugin" do 
   it "adds csrf protection and csrf helper methods" do
     app(:bare) do
       use Rack::Session::Cookie, :secret=>'1'


### PR DESCRIPTION
This pull request will allow the csrf plugin to skip configuring the csrf plugin like this:
```ruby
class App < Roda
  plugin :csrf, :skip_middleware=>true
end
```
It helped reduce the csrf middleware duplications.