### PR TITLE
Add status_303 plugin for lovers of RFC 7231

### DIFF
--- a/lib/roda/plugins/sinatra_helpers.rb
+++ b/lib/roda/plugins/sinatra_helpers.rb
@@ -226,6 +226,11 @@ class Roda
       CHARSET = 'charset'.freeze
       OPTS = {}.freeze
 
+      # Depend on the status_303 plugin.
+      def self.load_dependencies(app, _opts = nil)
+        app.plugin :status_303
+      end
+
       # Add delegate methods to the route block scope
       # calling request or response methods, unless the
       # :delegate option is false.
@@ -380,17 +385,6 @@ class Roda
         end
         alias url uri
         alias to uri
-
-        private
-
-        # Use a 303 response for non-GET responses if client uses HTTP 1.1.
-        def default_redirect_status
-          if @env[HTTP_VERSION] == HTTP11 && !is_get?
-            303
-          else
-            super
-          end
-        end
       end
 
       module ResponseMethods

--- a/lib/roda/plugins/status_303.rb
+++ b/lib/roda/plugins/status_303.rb
@@ -1,0 +1,32 @@
+# frozen-string-literal: true
+
+#
+class Roda
+  module RodaPlugins
+    # The status_303 plugin sets the default redirect status to be 303
+    # rather than 302 when the request is not a GET and the
+    # redirection occurs on an HTTP 1.1 connection as per RFC 7231.
+    # The author knows of no cases where this actually matters in
+    # practice.
+    #
+    # Example:
+    #
+    #   plugin :status_303
+    module Status303
+      module RequestMethods
+
+        private
+
+        def default_redirect_status
+          if env['HTTP_VERSION'] == 'HTTP/1.1' && !is_get?
+            303
+          else
+            super
+          end
+        end
+      end
+    end
+
+    register_plugin(:status_303, Status303)
+  end
+end

--- a/spec/plugin/status_303_spec.rb
+++ b/spec/plugin/status_303_spec.rb
@@ -1,0 +1,28 @@
+require File.expand_path("spec_helper", File.dirname(File.dirname(__FILE__)))
+
+describe "status_303 plugin" do
+  it 'uses a 302 for get requests' do
+    app(:status_303) do
+      request.redirect '/foo'
+      fail 'redirect should halt'
+    end
+    status.must_equal 302
+    body.must_equal ''
+    header('Location').must_equal '/foo'
+  end
+
+  it 'uses the code given when specified' do
+    app(:status_303) do
+      request.redirect '/foo', 301
+    end
+    status.must_equal 301
+  end
+
+  it 'uses 303 for post requests if request is HTTP 1.1, 302 for 1.0' do
+    app(:status_303) do
+      request.redirect '/foo'
+    end
+    status('HTTP_VERSION' => 'HTTP/1.1', 'REQUEST_METHOD'=>'POST').must_equal 303
+    status('HTTP_VERSION' => 'HTTP/1.0', 'REQUEST_METHOD'=>'POST').must_equal 302
+  end
+end


### PR DESCRIPTION
The implementation was pulled out of sinatra_helpers, which now depends
on the status_303 plugin.