### PR TITLE
Remove usage of deprecated request#[] in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -443,7 +443,7 @@ treat it as one route with an optional segment.  One simple way to do that is to
 use a parameter instead of an optional segment (e.g. +/items/123?opt=456+).
 
   r.is "items", Integer do |item_id|
-    optional_data = r['opt']
+    optional_data = r.params['opt']
   end
 
 However, if you really do want to use a optional segment, there are a couple different


### PR DESCRIPTION
Rack::Request#[] is deprecated and Roda should avoid using it in its documentation.