### PR TITLE
with_all_directories plugin and spec

### DIFF
--- a/lib/roda/plugins/with_all_directories.rb
+++ b/lib/roda/plugins/with_all_directories.rb
@@ -1,0 +1,48 @@
+# frozen-string-literal: true
+
+#
+class Roda
+  module RodaPlugins
+    # The with_all_directories plugin matches all directories in an URL and returns them to it's block.
+    # The directory part is returned without starting nor ending slashes. As directories are considered only items ending with a slash,
+    # so "/food/vegetables/" would match both items, but "/food/vegetables" would match only the food.
+    # The method always matches (returns empty string in the root), therefore the execution will stop at the end of the block, unless there is something else matching inside.
+    #
+    # Example:
+    #
+    #   r.with_all_directories do |category|
+    #
+    #     r.is '' do
+    #       # will match URL "/food/vegetables/"
+    #       # the category will be equal to "food/vegetables"
+    #       # now you can display a list of the category, for instance
+    #     end
+    #
+    #     r.is String do |item|
+    #       # will match URL "/food/vegetables/potatoes.html"
+    #       # the category will equal to "food/vegetables"
+    #       # now you can show the item (potatoes.html)
+    #     end
+    #
+    #   end
+    #
+    module WithAllDirectories
+      module RequestMethods
+
+        def with_all_directories
+          if remaining_path.empty?
+            block_result(yield(''))
+          else
+            matchdata = remaining_path.match(/\A(\/(.*))?(?=\/[^\/]*\z)/)
+            @remaining_path = matchdata.post_match
+            block_result(yield(matchdata.captures[1].to_s))
+          end
+          throw :halt, response.finish
+        end
+
+      end
+    end
+
+    register_plugin(:with_all_directories, WithAllDirectories)
+  end
+end

--- a/spec/plugin/with_all_directories_spec.rb
+++ b/spec/plugin/with_all_directories_spec.rb
@@ -1,0 +1,38 @@
+require_relative "../spec_helper"
+
+describe "with_all_directories plugin" do
+
+  it "test all posibile cases" do
+
+    app(:with_all_directories) do |r|
+      r.with_all_directories do |dirs|
+
+        r.is do
+          "is nil, #{dirs}"
+        end
+
+        r.is '' do
+          "is empty, #{dirs}"
+        end
+
+        r.is 'baz.html' do
+          "is baz.html, #{dirs}"
+        end
+
+      end
+
+      'should never be reached'
+    end
+
+    body('').must_equal 'is nil, '
+    body('/').must_equal 'is empty, '
+    status('/foo').must_equal 404
+    status('/foo/').must_equal 200
+    body('/foo/').must_equal 'is empty, foo'
+    body('/foo/bar/baz/').must_equal 'is empty, foo/bar/baz'
+    status('/foo/bar/baz/').must_equal 200
+    status('/foo/bar/baz').must_equal 404
+    body('/foo/bar/baz.html').must_equal 'is baz.html, foo/bar'
+  end
+
+end


### PR DESCRIPTION
This plugin matches all directories in an URL and returns them to it's block. For instance, "/food/" or "/food/vegetables/" are both considered as directories. At the end of the URL may be a "file", e.g. "/food/onion.html" or "/food/vegetables/yellow/potatoes.html". There is only one shared logic for all directories (to display the category or the item).