### PR TITLE
Fix broken html tag on home page and update compare styling

### DIFF
--- a/www/pages/index.erb
+++ b/www/pages/index.erb
@@ -164,7 +164,7 @@ END
 <section id="compare" class="bg-gray white">
   <div class="contain">
     <div class="compare sinatra">
-      <h2>Compare to Sinatra<h2>
+      <h2>Compare to Sinatra</h2>
       <p>Roda aims to take the ease of development and understanding that Sinatra brings, and enable it to scale to support the development of large web applications.</p>
       <a href="compare_to_sinatra.html" class="btn continue">Continue Reading</a>
     </div>

--- a/www/public/css/roda.css
+++ b/www/public/css/roda.css
@@ -85,6 +85,8 @@ a#logo {width: 290px; display: block; margin-top: 40px;}
 #features strong { font: 1.4em Bold; }
 #features p {margin-top: 0;}
 #compare h2 { font: 1.2em Bold;}
+
+.compare p {font-family: Thin; margin-top: 0;}
 #ecosystem h2{ padding-bottom: 0; margin-bottom: 0; }
 #ecosystem strong {font-size: 1.4em; padding: 20px 0; display: inline-block; position: relative;}
 #ecosystem svg.like {position: absolute; left: -70px; top: 22px;}
@@ -160,4 +162,3 @@ body.index :not(pre) > code[class*="language-"], body.index pre[class*="language
 .token.important, .token.bold { font-weight: bold; }
 .token.italic { font-style: italic; }
 .token.entity { cursor: help; }
-


### PR DESCRIPTION
One of the header tags was improperly closed at the bottom of the home page.
Paragraph styling felt a little odd in the comparison section.

Very small tweaks. This looks ready for deployment to me.