### PR TITLE
Raise nicer error when no route block defined

### DIFF
--- a/lib/roda.rb
+++ b/lib/roda.rb
@@ -134,6 +134,7 @@ class Roda
         # However, for performance, it's better to use #app to get direct
         # access to the underlying rack app.
         def call(env)
+          raise RodaError, "No route block defined for #{self}" if app.nil?
           app.call(env)
         end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -206,4 +206,11 @@ describe "integration" do
   it "should have route_block return the route block" do
     app{|r| 1}.route_block.call(nil).must_equal 1
   end
+
+  it "should raise an error if called without a route block" do
+    Object.const_set(:TestAppName, app(:bare){})
+    ex = proc{ app.call({}) }.must_raise
+    ex.message.must_equal 'No route block defined for TestAppName'
+    Object.send(:remove_const, :TestAppName)
+  end
 end


### PR DESCRIPTION
This is something that I've come across a few times while TDDing a Roda app.

Trying to use a Roda object that doesn't have a route block would result in:

    NoMethodError:
       undefined method `call' for nil:NilClass

Now the error message is:

    RodaError:
        No route block defined for MyApp