### PR TITLE
Add source code URI to gemspec

### DIFF
--- a/roda.gemspec
+++ b/roda.gemspec
@@ -9,6 +9,9 @@ Gem::Specification.new do |s|
   s.homepage          = "http://roda.jeremyevans.net"
   s.license           = "MIT"
   s.required_ruby_version = ">= 1.9.2"
+  s.metadata          = { 
+    "source_code_uri" => "https://github.com/jeremyevans/roda" 
+  }
 
   s.files = %w'README.rdoc MIT-LICENSE CHANGELOG Rakefile' + Dir['doc/*.rdoc'] + Dir['doc/release_notes/*.txt'] + Dir['{lib,spec}/**/*.rb'] + Dir['spec/views/*'] + Dir['spec/views/about/*'] + Dir['spec/assets/{css/{app.scss,raw.css,no_access.css},js/head/app.js}']
   s.extra_rdoc_files = %w'README.rdoc MIT-LICENSE CHANGELOG' + Dir["doc/*.rdoc"] + Dir['doc/release_notes/*.txt']


### PR DESCRIPTION
As defined in https://guides.rubygems.org/specification-reference/

Somebody recently sent a PR to categorize roda on the Ruby Toolbox (see https://github.com/rubytoolbox/catalog/pull/175), and I noticed the library does not have a proper linking to it's github repo and therefore is missing all github-related stats:

![bildschirmfoto vom 2018-12-03 11 43 39](https://user-images.githubusercontent.com/13972/49369045-bee40a80-f6f0-11e8-8cfc-ceef574c3376.png)

By adding it to the gemspec (and releasing ;) the proper linking should be picked up, and users will also be able to go to the github repo from rubygems.org directly as well.