### PR TITLE
Add yield_response plugin

### DIFF
--- a/lib/roda/plugins/yield_response.rb
+++ b/lib/roda/plugins/yield_response.rb
@@ -1,0 +1,73 @@
+# frozen-string-literal: true
+
+#
+class Roda
+  module RodaPlugins
+    # The yield_response plugin yields +#response+ as an optional second
+    # argument to the +route+ block, so you can manipulate it more conveniently:
+    #
+    #   class App < Roda
+    #     plugin :yield_response
+    #     route do |req, res|
+    #       req.post do
+    #         @artist = Artist.create(name: req.params['name'].to_s)
+    #         res['Content-Type'] = 'application/json'
+    #         res.status = 201
+    #         res.write @artist.to_json
+    #       end
+    #     end
+    #   end
+    #
+    # The plugin runs in compatibility mode by default, which incurs the tiny
+    # performance penalty of the +hooks+ plugin. At the cost of compatibility
+    # with +hooks+, you can run the +yield_response+ plugin with zero
+    # performance penalty by configuring it in fast mode:
+    #
+    #   class App < Roda
+    #     plugin :yield_response, mode: "fast"
+    #     plugin :hooks
+    #   end
+    module YieldResponse
+      DEFAULT_OPTIONS = { mode: "compatible" }.freeze
+
+      def self.load_dependencies(app, opts = DEFAULT_OPTIONS)
+        if opts[:mode] == "fast"
+          app.plugin YieldResponse::Fast
+        else
+          app.plugin(:hooks)
+          app.plugin YieldResponse::Compatible
+        end
+      end
+
+      # Respect the hooks plugin's call to +_roda_before+
+      module Compatible
+        module ClassMethods
+          def rack_app_route_block(block)
+            lambda do |r|
+              _roda_before
+              instance_exec(r, response, &block)
+            end
+          end
+        end
+      end
+
+      # In 'fast' mode, YieldResponse just overrides Roda's default #call,
+      # which means it doesn't incur the small performance penalty of
+      # +instance_exec+, nor the larger penalty of loading the +hooks+ plugin.
+      module Fast
+        module InstanceMethods
+          def call(&block)
+            catch(:halt) do
+              req = @_request
+              res = @_response
+              req.block_result(instance_exec(req, res, &block))
+              res.finish
+            end
+          end
+        end
+      end
+    end
+
+    register_plugin :yield_response, YieldResponse
+  end
+end

--- a/spec/plugin/yield_response_spec.rb
+++ b/spec/plugin/yield_response_spec.rb
@@ -1,0 +1,79 @@
+require_relative "../spec_helper"
+
+describe "yield_response plugin" do
+  describe "configured in fast mode" do
+    it "yields #response as a second route block argument" do
+      app(:bare) do
+        plugin :yield_response, mode: "fast"
+        route do |req, res|
+          res.status = 401
+          "Unauthorized"
+        end
+      end
+      status("/").must_equal 401
+    end
+
+    it "still supports a single route block argument" do
+      app(:bare) do
+        plugin :yield_response, mode: "fast"
+        route { |r| "OK" }
+      end
+      body("/").must_equal "OK"
+    end
+
+    it "is incompatible with the hooks plugin" do
+      app(:hooks) { "OK" }
+      app.plugin(:yield_response, mode: "fast")
+      proc { body("/") }.must_raise(ArgumentError)
+    end
+  end
+
+  describe "in its default configuration" do
+    mock_logger = Class.new { attr_accessor :message }
+
+    it "works with hooks when loaded last" do
+      logger = mock_logger.new
+      app(:bare) do
+        plugin :hooks
+        before { @user_id = 1 }
+        after { logger.message = "loaded last" }
+        plugin :yield_response
+        route do |req, res|
+          res.status = 401
+          @user_id.to_s
+        end
+      end
+      status, header, body = req
+      status.must_equal 401
+      body.must_equal ["1"]
+      logger.message.must_equal "loaded last"
+    end
+
+    it "works with hooks when loaded first" do
+      logger = mock_logger.new
+      app(:bare) do
+        plugin :yield_response
+        plugin :hooks
+        before { @user_id = 1 }
+        after { logger.message = "loaded first" }
+        route do |req, res|
+          res.status = 401
+          @user_id.to_s
+        end
+      end
+      status, header, body = req
+      status.must_equal 401
+      body.must_equal ["1"]
+      logger.message.must_equal "loaded first"
+    end
+
+    it "still supports a single route block argument" do
+      app(:bare) do
+        plugin :yield_response
+        route { |r| "OK" }
+      end
+
+      status('/').must_equal(200)
+    end
+  end
+end

--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -43,6 +43,7 @@
       <li><a href="rdoc/classes/Roda/RodaPlugins/StatusHandler.html">status_handler</a>: Adds status_handler method for handling responses without bodies for a given status code.</li>
       <li><a href="rdoc/classes/Roda/RodaPlugins/TypeRouting.html">type_routing</a>: Route based on path extensions and Accept headers.</li>
       <li><a href="rdoc/classes/Roda/RodaPlugins/UnescapePath.html">unescape_path</a>: Decodes URL-encoded PATH_INFO before routing.</li>
+      <li><a href="rdoc/classes/Roda/RodaPlugins/YieldResponse.html">yield_response</a>: Yields to the route block with #response as an optional second argument.</li>
     </ul></li>
     <li>Rendering/View: <ul>
       <li><a href="rdoc/classes/Roda/RodaPlugins/Assets.html">assets</a>: Adds support for rendering CSS/JS javascript assets on the fly in development, or compiling them into a single compressed file in production.</li>


### PR DESCRIPTION
The `yield_response` plugin adds the RodaResponse instance as an optional second argument to the `route` block, which makes the route block's signature match that of express.js and Node's default HTTP server. The aim is to make it easier to see that the response is in scope, and to make Roda more intuitive to developers coming from Node.

```ruby
class App < Roda
  plugin :yield_response
  route do |req, res|
    res.status = 203
    res.write = "Hello, #{req.params['name']}"
  end
end
```

