### PR TITLE
Fix typo in route_block_args example

### DIFF
--- a/lib/roda/plugins/route_block_args.rb
+++ b/lib/roda/plugins/route_block_args.rb
@@ -11,7 +11,7 @@ class Roda
     #
     #   class App < Roda
     #     plugin :route_block_args do
-    #       [request, params, response]
+    #       [request, request.params, response]
     #     end
     #
     #     route do |r, params, res|


### PR DESCRIPTION
In the inline documentation re: configuring the route_block_args plugin, I think the example needs to call `request.params` instead `params`.