### PR TITLE
Add match_hook plugin

### DIFF
--- a/lib/roda/plugins/match_hook.rb
+++ b/lib/roda/plugins/match_hook.rb
@@ -3,6 +3,14 @@
 #
 class Roda
   module RodaPlugins
+    # The match_hook plugin adds hooks that are called upon a successful match
+    # by any of the matchers.
+    #
+    #   plugin :match_hook
+    #
+    #   match_hook do
+    #     logger.debug("#{request.matched_path} matched. #{request.remaining_path} remaining.")
+    #   end
     module MatchHook
       def self.configure(app)
         app.opts[:match_hooks] ||= []
@@ -15,6 +23,7 @@ class Roda
           super
         end
 
+        # Add a match hook.
         def match_hook(&block)
           opts[:match_hooks] << define_roda_method("match_hook", 0, &block)
 

--- a/lib/roda/plugins/match_hook.rb
+++ b/lib/roda/plugins/match_hook.rb
@@ -1,0 +1,58 @@
+# frozen-string-literal: true
+
+#
+class Roda
+  module RodaPlugins
+    module MatchHook
+      def self.configure(app)
+        app.opts[:match_hooks] ||= []
+      end
+
+      module ClassMethods
+        # Freeze the array of hook methods when freezing the app
+        def freeze
+          opts[:match_hooks].freeze
+          super
+        end
+
+        def match_hook(&block)
+          opts[:match_hooks] << define_roda_method("match_hook", 0, &block)
+
+          if opts[:match_hooks].length == 1
+            class_eval("alias _match_hook #{opts[:match_hooks].first}", __FILE__, __LINE__)
+          else
+            class_eval("def _match_hook; #{opts[:match_hooks].join(';')} end", __FILE__, __LINE__)
+          end
+
+          public :_match_hook
+
+          nil
+        end
+      end
+
+      module InstanceMethods
+        # Default method if no match hooks are defined.
+        def _match_hook
+        end
+      end
+
+      module RequestMethods
+        private
+
+        def if_match(*)
+          super { |*a|
+            scope._match_hook
+            yield *a
+          }
+        end
+
+        def always
+          scope._match_hook
+          super
+        end
+      end
+    end
+
+    register_plugin :match_hook, MatchHook
+  end
+end

--- a/spec/plugin/match_hook_spec.rb
+++ b/spec/plugin/match_hook_spec.rb
@@ -1,0 +1,25 @@
+require_relative "../spec_helper"
+
+describe "match hook plugin" do
+  before do
+    hooks = 0
+
+    app(:bare) do
+      plugin :match_hook
+
+      match_hook do
+        hooks += 1
+      end
+
+      route do |r|
+        r.get "foo" do
+          hooks.to_s
+        end
+      end
+    end
+  end
+
+  it "calls match_hook on a successful match" do
+    body("/foo").must_equal "1"
+  end
+end

--- a/www/pages/documentation.erb
+++ b/www/pages/documentation.erb
@@ -31,6 +31,7 @@
       <li><a href="rdoc/classes/Roda/RodaPlugins/ErrorHandler.html">error_handler</a>: Adds ability to automatically handle errors raised by the application.</li>
       <li><a href="rdoc/classes/Roda/RodaPlugins/Head.html">head</a>: Treat HEAD requests like GET requests with an empty response body.</li>
       <li><a href="rdoc/classes/Roda/RodaPlugins/Hooks.html">hooks</a>: Adds before/after hook methods.</li>
+      <li><a href="rdoc/classes/Roda/RodaPlugins/MatchHook.html">match_hook</a>: Adds a hook method which is called when a path segment is matched.</li>
       <li><a href="rdoc/classes/Roda/RodaPlugins/MultiRoute.html">multi_route</a>: Allows for multiple named route blocks that can be dispatched to inside main route block.</li>
       <li><a href="rdoc/classes/Roda/RodaPlugins/MultiRun.html">multi_run</a>: Adds the ability to dispatch to multiple rack applications based on the request path prefix.</li>
       <li><a href="rdoc/classes/Roda/RodaPlugins/NotAllowed.html">not_allowed</a>: Adds support for automatically returning 405 Method Not Allowed responses.</li>


### PR DESCRIPTION
Adds the `match_hook` plugin, allowing a block (or multiple) to be called on each successful match of the routing tree.