### PR TITLE
Avoid issues where loggers don't match signature and also allow for procs

### DIFF
--- a/lib/roda/plugins/common_logger.rb
+++ b/lib/roda/plugins/common_logger.rb
@@ -20,8 +20,14 @@ class Roda
     #   plugin :common_logger, Logger.new('filename')
     module CommonLogger
       def self.configure(app, logger=nil)
+        raise "logger doesn't respond to write()" unless !logger.nil? && logger.respond_to?(:write)
+        raise "logger doesn't respond to <<" unless !logger.nil? && logger.respond_to?(:<<)
+        raise "logger doesn't respond to call()" unless !logger.nil? && logger.respond_to?(:call)
+
         app.opts[:common_logger] = logger || app.opts[:common_logger] || $stderr
-        app.opts[:common_logger_meth] = app.opts[:common_logger].method(logger.respond_to?(:write) ? :write : :<<)
+        app.opts[:common_logger_meth] = app.opts[:common_logger].method(:write) if logger.respond_to?(:write)
+        app.opts[:common_logger_meth] = app.opts[:common_logger].method(:<<) if logger.respond_to?(:<<)
+        app.opts[:common_logger_meth] = app.opts[:common_logger] if logger.respond_to?(:call)
       end
 
       if RUBY_VERSION >= '2.1'


### PR DESCRIPTION
Right now if you pass the common_logger plugin a modern logger it might not respond to write or <<, see: async's Async.logger. In reality, since we're storing the means and not the context it's easier if we also allow the user to pass in something that is callable.