### PR TITLE
Incorrect assets plugin output on comments edge case

### DIFF
--- a/lib/roda/plugins/assets.rb
+++ b/lib/roda/plugins/assets.rb
@@ -494,7 +494,7 @@ class Roda
             file = "#{dirs.join('/')}/#{file}" if dirs && o[:group_subdirs]
             file = "#{o[:"#{type}_path"]}#{file}"
             app.read_asset_file(file, type)
-          end.join
+          end.join("\n")
 
           unless o[:concat_only]
             content = compress_asset(content, type)


### PR DESCRIPTION
The assets plugin produced incorrect code (e.g. in JS) when two consecutive assets present the following conditions:

1) the first file ends with a _line_ comment, such as a `//` comment in JS
2) the first file does not end with a newline character sequence
3) the second file starts with a comment block, such as `/*` in JS

Can be seen with bootstrap.min.js and holder.min.js:

![image](https://user-images.githubusercontent.com/28158/68176577-b6fbad00-ffc8-11e9-9fd5-e9a9fc145002.png)

Notice at the end of line 9 that holder.js' comment block start gets commented out by Bootstrap's trailing comment line.