### PR TITLE
Make run_append_slash work with run_handler

### DIFF
--- a/lib/roda/plugins/run_append_slash.rb
+++ b/lib/roda/plugins/run_append_slash.rb
@@ -33,7 +33,7 @@ class Roda
         # does not contain a trailing slash, a trailing slash is appended to the
         # path internally, or a redirect is issued when configured with
         # <tt>use_redirects: true</tt>.
-        def run(app)
+        def run(*)
           if remaining_path.empty?
             if scope.opts[:run_append_slash_redirect]
               redirect("#{path}/")

--- a/spec/plugin/run_append_slash_spec.rb
+++ b/spec/plugin/run_append_slash_spec.rb
@@ -74,4 +74,23 @@ describe "run_append_slash plugin" do
     body('/sub/bar/baz').must_equal 'sub-bar-baz'
     status('/sub/bar/baz/').must_equal 404
   end
+
+  it "works with run_handler plugin" do
+    sub = app(:bare) { }
+
+    app(:bare) do
+      plugin :run_handler
+      plugin :run_append_slash
+
+      route do |r|
+        r.run sub, not_found: :pass
+
+        r.root do
+          "main"
+        end
+      end
+    end
+
+    body("/").must_equal 'main'
+  end
 end


### PR DESCRIPTION
If run_handler plugin was loaded before run_append_slash plugin,
Request#run wouldn't accept multiple arguments anymore, so one for
example wouldn't be able to pass `not_found: :pass`. We fix that by
forwarding any number of arguments in run_handler plugin.