### PR TITLE
Fix context id assertions of exception page spec

### DIFF
--- a/spec/plugin/exception_page_spec.rb
+++ b/spec/plugin/exception_page_spec.rb
@@ -141,7 +141,7 @@ describe "exception_page plugin" do
     body = body('HTTP_ACCEPT'=>'text/html')
     body.must_include "RuntimeError: foo"
     body.must_include __FILE__
-    body.wont_include 'id="c0"'
+    body.must_include 'id="c0"'
   end
 
   it "should still show line numbers if the line content cannot be displayed" do
@@ -152,7 +152,7 @@ describe "exception_page plugin" do
     body.must_include "RuntimeError: foo"
     body.must_include "foo-bar.rb:#{4200+42}"
     body.must_include __FILE__
-    body.wont_include 'id="c0"'
+    body.must_include 'id="c1"'
   end
 
   it "should serve exception page assets" do


### PR DESCRIPTION
Hi! 

I‘m trying to run the test suite at local and experienced a test failure:

```zsh
$ ruby spec/plugin/exception_page_spec.rb
Run options: --seed 48567

# Running:

...F..

Finished in 0.192085s, 31.2362 runs/s, 827.7585 assertions/s.

  1) Failure:
exception_page plugin#test_0004_should handle backtrace lines in unexpected forms [spec/plugin/exception_page_spec.rb:144]:
```

I found it‘s because [this test](https://github.com/jeremyevans/roda/blob/39ce95d5f9931d962d840cea487c8b2ffb26711d/spec/plugin/exception_page_spec.rb#L135-L145):

https://github.com/jeremyevans/roda/blob/39ce95d5f9931d962d840cea487c8b2ffb26711d/spec/plugin/exception_page_spec.rb#L135-L145

is the test itself. When we set the frame:

```ruby
begin
  lineno -= 1
  lines = ::File.readlines(filename)
  pre_lineno = frame[:pre_context_lineno] = [lineno-context, 0].max
  frame[:pre_context] = lines[pre_lineno...lineno]
  frame[:context_line] = lines[lineno].chomp
  post_lineno = frame[:post_context_lineno] = [lineno+context, lines.size].min
  frame[:post_context] = lines[lineno+1..post_lineno]
rescue
end
```

`::File.readlines` of a existing file will not raise error. Hence `frame[:context_line]` got set.

```ruby
#{frame[:context_line] ? (<<END2) : '</li>'
<div class="context" id="c#{id}">
```

And the context id will start from 0.

The [other similar test](https://github.com/jeremyevans/roda/blob/39ce95d5f9931d962d840cea487c8b2ffb26711d/spec/plugin/exception_page_spec.rb#L147-L156):

https://github.com/jeremyevans/roda/blob/39ce95d5f9931d962d840cea487c8b2ffb26711d/spec/plugin/exception_page_spec.rb#L147-L156

We specified a file that does not exist (`foo-bar.rb`). So `::File.readlines`
of this nonexistent raises an error. 

```ruby
begin
  lineno -= 1
  lines = ::File.readlines(filename)
  pre_lineno = frame[:pre_context_lineno] = [lineno-context, 0].max
  frame[:pre_context] = lines[pre_lineno...lineno]
  frame[:context_line] = lines[lineno].chomp
  post_lineno = frame[:post_context_lineno] = [lineno+context, lines.size].min
  frame[:post_context] = lines[lineno+1..post_lineno]
rescue
end
```

Hence `frame[:context_line]` did not got set, so the context id starts from 1.

<hr>

I updated both assertions to use `must_include` for what‘s happening here.