### PR TITLE
fix typo in typecast_params documentation

### DIFF
--- a/doc/release_notes/3.3.0.txt
+++ b/doc/release_notes/3.3.0.txt
@@ -248,7 +248,7 @@
   Note that if there are multiple conversion errors raised inside a
   convert! or convert_each!  block, they are recorded and a single
   Roda::RodaPlugins::TypecastParams::Error instance is raised after
-  processing the block.  TypecastParams::Error#params_names can be
+  processing the block.  TypecastParams::Error#param_names can be
   called on the exception to get an array of all parameter names
   with conversion issues, and TypecastParams::Error#all_errors
   can be used to get an array of all Error instances.

--- a/lib/roda/plugins/typecast_params.rb
+++ b/lib/roda/plugins/typecast_params.rb
@@ -229,7 +229,7 @@ class Roda
     #
     # Note that if there are multiple conversion Error raised inside a +convert!+ or +convert_each!+ 
     # block, they are recorded and a single TypecastParams::Error instance is raised after
-    # processing the block.  TypecastParams::Error#params_names can be called on the exception to
+    # processing the block.  TypecastParams::Error#param_names can be called on the exception to
     # get an array of all parameter names with conversion issues, and TypecastParams::Error#all_errors
     # can be used to get an array of all Error instances.
     #


### PR DESCRIPTION
Hello! I found this tiny typo in the `typecast_params` plugin documentation. That's it <3