### PR TITLE
CI cleanups and re-add truffleruby-head to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,12 @@ jobs:
       matrix:
         ruby: [ 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, jruby-9.1.17.0, jruby-9.2.13.0 ]
     name: ${{ matrix.ruby }}
+    env:
+      BUNDLE_GEMFILE: .ci.gemfile
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-      env:
-        BUNDLE_GEMFILE: .ci.gemfile
     - run: bundle exec rake
-      env:
-        BUNDLE_GEMFILE: .ci.gemfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', 'jruby-9.1.17.0', 'jruby-9.2.13.0' ]
+        ruby: [ 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, jruby-9.1.17.0, jruby-9.2.13.0 ]
     name: ${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, jruby-9.1.17.0, jruby-9.2.13.0 ]
+        ruby: [ 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, jruby-9.1.17.0, jruby-9.2.13.0, truffleruby-head ]
     name: ${{ matrix.ruby }}
     env:
       BUNDLE_GEMFILE: .ci.gemfile


### PR DESCRIPTION
TruffleRuby was uninentionally removed in https://github.com/jeremyevans/roda/commit/e88ecf456d4df93b8ab0b28d41a9b1298b18b86f#commitcomment-44571643, this adds it back.
I also took the opportunity to clean up a bit the ci.yml.