### PR TITLE
Subclass Roda class in middleware plugin only when configuration block is passed

### DIFF
--- a/lib/roda/plugins/middleware.rb
+++ b/lib/roda/plugins/middleware.rb
@@ -85,8 +85,9 @@ class Roda
         # Make a subclass of +mid+ to use as the current middleware,
         # and store +app+ as the next middleware to call.
         def initialize(mid, app, *args, &block)
-          @mid = Class.new(mid)
+          @mid = mid
           if configure = @mid.opts[:middleware_configure]
+            @mid = Class.new(@mid)
             configure.call(@mid, *args, &block)
           elsif block || !args.empty?
             raise RodaError, "cannot provide middleware args or block unless loading middleware plugin with a block"

--- a/spec/plugin/middleware_spec.rb
+++ b/spec/plugin/middleware_spec.rb
@@ -81,9 +81,14 @@ describe "middleware plugin" do
     body.must_equal 'a'
   end
 
-  it "makes middleware always use a subclass of the app" do
-    app(:middleware) do |r|
-      r.get{opts[:a]}
+  it "makes middleware use a subclass of the app when configuration block is passed in" do
+    app(:bare) do
+      plugin :middleware do |mid, *args, &block|
+        # ...
+      end
+      route do |r|
+        r.get{opts[:a]}
+      end
     end
     app.opts[:a] = 'a'
     a = app


### PR DESCRIPTION
When I was working on support for custom auth classes for Rodauth, I noticed that a `Rodauth::Auth` instance used an instance of an anonymous Roda class.

```rb
require "rodauth"

class RodauthMain < Rodauth::Auth
  # ...
end

class RodauthApp < Roda
  plugin :middleware
  plugin :rodauth, auth_class: RodauthMain

  route do |r|
    rodauth.class.roda_class #=> RodauthApp
    rodauth.scope.class #=> #<Class:0x00007f960188e6b0>
  end
end

use Rodauth::App
run -> (env) { [200, {}, []] }
```

This is because the `middleware` plugin is subclassing the Roda class, which is necessary when a configure block is passed to the plugin, but I think it might not be otherwise.

With the goal of improved introspectability, I thought we could skip creating the subclass in case a configuration block is not passed in.
