### PR TITLE
Allow for middleware with keyword arguments.

### DIFF
--- a/lib/roda.rb
+++ b/lib/roda.rb
@@ -328,6 +328,8 @@ class Roda
           @app = nil
         end
 
+        ruby2_keywords(:use) if respond_to?(:ruby2_keywords, true)
+
         private
 
         # Return the number of required argument, optional arguments,

--- a/spec/plugin/middleware_spec.rb
+++ b/spec/plugin/middleware_spec.rb
@@ -102,6 +102,31 @@ describe "middleware plugin" do
     proc{app(:bare){use(a1){}; route{}; build_rack_app}}.must_raise Roda::RodaError
   end
 
+  it "supports configuring middleware with keyword arguments" do
+    m1 = Class.new do
+      def initialize(app, key:)
+        @app = app
+        @key = key
+      end
+
+      def call(env)
+        status, headers, _body = @app.call(env)
+
+        [status, headers, [@key]]
+      end
+    end
+
+    app(:bare) do
+      use m1, key: 'test'
+
+      route do
+        'a'
+      end
+    end
+
+    body.must_equal 'test'
+  end
+
   it "supports configuring middleware via a block" do
     a1 = app(:bare) do
       plugin :middleware do |mid, *args, &block|


### PR DESCRIPTION
The previous approach wasn't working in Ruby v3 for middleware which use keyword arguments.

I'm making use of the existing `_define_roda_method_arg_numbers` method and `RUBY_VERSION` checks to ensure the final hash argument is only translated into keyword arguments if appropriate. I've no experience of the Roda source though, so do let me know if there's a better way to handle all of this!