### PR TITLE
Remove inaccurate comment in content_for plugin

### DIFF
--- a/lib/roda/plugins/content_for.rb
+++ b/lib/roda/plugins/content_for.rb
@@ -62,8 +62,7 @@ class Roda
       end
 
       # Configure whether to append or overwrite if content_for
-      # is called multiple times to set data. Overwrite is default, use
-      # the :append option to append.
+      # is called multiple times with the same key.
       def self.configure(app, opts = OPTS)
         app.opts[:append_content_for] = opts.fetch(:append, true)
       end


### PR DESCRIPTION
The default behavior (append mode) is already mentioned in the module docs so I figured we might as well remove the sentence entirely.

Thanks for the awesome libraries Jeremy!