### PR TITLE
Path helpers support kwargs without warnings

### DIFF
--- a/lib/roda/plugins/path.rb
+++ b/lib/roda/plugins/path.rb
@@ -148,11 +148,13 @@ class Roda
                 # Allow calling private _method to get path
                 relative_path(request.script_name.to_s + send(_meth, *a, &blk))
               end
+              ruby2_keywords(meth) if respond_to?(:ruby2_keywords, true)
             elsif add_script_name
               define_method(meth) do |*a, &blk|
                 # Allow calling private _method to get path
                 request.script_name.to_s + send(_meth, *a, &blk)
               end
+              ruby2_keywords(meth) if respond_to?(:ruby2_keywords, true)
             else
               define_method(meth, &block)
             end
@@ -171,6 +173,7 @@ class Roda
             end
 
             define_method(url_meth, &url_block)
+            ruby2_keywords(url_meth) if respond_to?(:ruby2_keywords, true)
           end
 
           nil

--- a/spec/plugin/path_spec.rb
+++ b/spec/plugin/path_spec.rb
@@ -138,6 +138,37 @@ describe "path plugin" do
     path_app(:foo, :url=>true){"/bar/foo"}
     body("foo_url", 'HTTP_HOST'=>'example.org:81', "rack.url_scheme"=>'http', 'SERVER_PORT'=>81).must_equal "http://example.org:81/bar/foo"
   end
+
+  it "supports keyword argument when opts[:add_script_name] is true" do
+    app(:bare) do
+      opts[:add_script_name] = true
+      plugin :path
+      path(:foo) {|bar:| "/foo/#{bar}"}
+      route{|r| foo_path(bar: "bar")}
+    end
+
+    body.must_equal "/foo/bar"
+  end
+
+  it "supports keyword arguments when :relative is true" do
+    app(:bare) do
+      plugin :path
+      path(:foo, relative: true) {|bar:| "/foo/#{bar}"}
+      route{|r| foo_path(bar: "bar")}
+    end
+
+    body.must_equal "./foo/bar"
+  end
+
+  it "supports keyword arguments when :url is true" do
+    app(:bare) do
+      plugin :path
+      path(:foo, url: true) {|bar:| "/foo/#{bar}"}
+      route{|r| foo_url(bar: "bar")}
+    end
+
+    body("/", 'HTTP_HOST'=>'example.org:81', "rack.url_scheme"=>'http', 'SERVER_PORT'=>81).must_equal "http://example.org:81/foo/bar"
+  end
 end
 
 describe "path plugin" do 

--- a/spec/plugin/path_spec.rb
+++ b/spec/plugin/path_spec.rb
@@ -139,35 +139,37 @@ describe "path plugin" do
     body("foo_url", 'HTTP_HOST'=>'example.org:81', "rack.url_scheme"=>'http', 'SERVER_PORT'=>81).must_equal "http://example.org:81/bar/foo"
   end
 
-  it "supports keyword argument when opts[:add_script_name] is true" do
-    app(:bare) do
-      opts[:add_script_name] = true
-      plugin :path
-      path(:foo) {|bar:| "/foo/#{bar}"}
-      route{|r| foo_path(bar: "bar")}
+  if RUBY_VERSION >= "2.1"
+    it "supports keyword argument when opts[:add_script_name] is true" do
+      app(:bare) do
+        opts[:add_script_name] = true
+        plugin :path
+        path(:foo) {|bar:| "/foo/#{bar}"}
+        route{|r| foo_path(bar: "bar")}
+      end
+
+      body.must_equal "/foo/bar"
     end
 
-    body.must_equal "/foo/bar"
-  end
+    it "supports keyword arguments when :relative is true" do
+      app(:bare) do
+        plugin :path
+        path(:foo, relative: true) {|bar:| "/foo/#{bar}"}
+        route{|r| foo_path(bar: "bar")}
+      end
 
-  it "supports keyword arguments when :relative is true" do
-    app(:bare) do
-      plugin :path
-      path(:foo, relative: true) {|bar:| "/foo/#{bar}"}
-      route{|r| foo_path(bar: "bar")}
+      body.must_equal "./foo/bar"
     end
 
-    body.must_equal "./foo/bar"
-  end
+    it "supports keyword arguments when :url is true" do
+      app(:bare) do
+        plugin :path
+        path(:foo, url: true) {|bar:| "/foo/#{bar}"}
+        route{|r| foo_url(bar: "bar")}
+      end
 
-  it "supports keyword arguments when :url is true" do
-    app(:bare) do
-      plugin :path
-      path(:foo, url: true) {|bar:| "/foo/#{bar}"}
-      route{|r| foo_url(bar: "bar")}
+      body("/", 'HTTP_HOST'=>'example.org:81', "rack.url_scheme"=>'http', 'SERVER_PORT'=>81).must_equal "http://example.org:81/foo/bar"
     end
-
-    body("/", 'HTTP_HOST'=>'example.org:81', "rack.url_scheme"=>'http', 'SERVER_PORT'=>81).must_equal "http://example.org:81/foo/bar"
   end
 end
 

--- a/spec/plugin/path_spec.rb
+++ b/spec/plugin/path_spec.rb
@@ -141,32 +141,38 @@ describe "path plugin" do
 
   if RUBY_VERSION >= "2.1"
     it "supports keyword argument when opts[:add_script_name] is true" do
-      app(:bare) do
-        opts[:add_script_name] = true
-        plugin :path
-        path(:foo) {|bar:| "/foo/#{bar}"}
-        route{|r| foo_path(bar: "bar")}
-      end
+      eval(<<-'RUBY')
+        app(:bare) do
+          opts[:add_script_name] = true
+          plugin :path
+          path(:foo) {|bar:| "/foo/#{bar}"}
+          route{|r| foo_path(bar: "bar")}
+        end
+      RUBY
 
       body.must_equal "/foo/bar"
     end
 
     it "supports keyword arguments when :relative is true" do
-      app(:bare) do
-        plugin :path
-        path(:foo, relative: true) {|bar:| "/foo/#{bar}"}
-        route{|r| foo_path(bar: "bar")}
-      end
+      eval(<<-'RUBY')
+        app(:bare) do
+          plugin :path
+          path(:foo, relative: true) {|bar:| "/foo/#{bar}"}
+          route{|r| foo_path(bar: "bar")}
+        end
+      RUBY
 
       body.must_equal "./foo/bar"
     end
 
     it "supports keyword arguments when :url is true" do
-      app(:bare) do
-        plugin :path
-        path(:foo, url: true) {|bar:| "/foo/#{bar}"}
-        route{|r| foo_url(bar: "bar")}
-      end
+      eval(<<-'RUBY')
+        app(:bare) do
+          plugin :path
+          path(:foo, url: true) {|bar:| "/foo/#{bar}"}
+          route{|r| foo_url(bar: "bar")}
+        end
+      RUBY
 
       body("/", 'HTTP_HOST'=>'example.org:81', "rack.url_scheme"=>'http', 'SERVER_PORT'=>81).must_equal "http://example.org:81/foo/bar"
     end


### PR DESCRIPTION
Call `ruby2_keywords` on path methods that accept splatted arguments
to prevent warnings on Ruby 2.7.