### PR TITLE
Support specifying script type

### DIFF
--- a/lib/roda/plugins/assets.rb
+++ b/lib/roda/plugins/assets.rb
@@ -720,10 +720,15 @@ class Roda
             attrs[:integrity] = "#{algo}-#{h([[hash].pack('H*')].pack('m').tr("\n", ''))}"
           end
 
+          unless attrs[:type]
+            attrs = Hash[attrs]
+            attrs[:type] = "text/javascript"
+          end
+
           attrs = attrs.map{|k,v| "#{k}=\"#{h(v)}\""}.join(' ')
 
           if ltype == :js
-            tag_start = "<script type=\"text/javascript\" #{attrs} src=\""
+            tag_start = "<script #{attrs} src=\""
             tag_end = "\"></script>"
           else
             tag_start = "<link rel=\"stylesheet\" #{attrs} href=\""

--- a/lib/roda/plugins/assets.rb
+++ b/lib/roda/plugins/assets.rb
@@ -201,7 +201,7 @@ class Roda
     # If you want to precompile your assets, so they do not need to be compiled
     # every time you boot the application, you can provide a :precompiled option
     # when loading the plugin.  The value of this option should be the filename
-    # where the compiled asset metadata is stored.  
+    # where the compiled asset metadata is stored.
     #
     # If the compiled asset metadata file does not exist when the assets plugin
     # is loaded, the plugin will run in non-compiled mode.  However, when you call
@@ -418,7 +418,7 @@ class Roda
         end
 
         [:css_headers, :js_headers, :css_opts, :js_opts, :dependencies].each do |s|
-          opts[s] ||= {} 
+          opts[s] ||= {}
         end
 
         expanded_deps = opts[:expanded_dependencies] = {}

--- a/spec/plugin/assets_spec.rb
+++ b/spec/plugin/assets_spec.rb
@@ -722,11 +722,15 @@ END
     end
 
     it '#assets must_include attributes given' do
-      app.allocate.assets([:js, :head], 'a'=>'b').must_equal '<script type="text/javascript" a="b" src="/assets/js/head/app.js"></script>'
+      app.allocate.assets([:js, :head], 'a'=>'b').must_equal '<script a="b" type="text/javascript" src="/assets/js/head/app.js"></script>'
+    end
+
+    it '#assets must_include type given' do
+      app.allocate.assets([:js, :head], type: 'module').must_equal '<script type="module" src="/assets/js/head/app.js"></script>'
     end
 
     it '#assets should escape attribute values given' do
-      app.allocate.assets([:js, :head], 'a'=>'b"e').must_equal '<script type="text/javascript" a="b&quot;e" src="/assets/js/head/app.js"></script>'
+      app.allocate.assets([:js, :head], 'a'=>'b"e').must_equal '<script a="b&quot;e" type="text/javascript" src="/assets/js/head/app.js"></script>'
     end
 
     it 'requests for assets should return 304 if the asset has not been modified' do
@@ -826,14 +830,14 @@ END
     it 'should support :precompiled option' do
       app.plugin :assets, :precompiled=>metadata_file
       File.exist?(metadata_file).must_equal false
-      app.allocate.assets([:js, :head]).must_equal '<script type="text/javascript"  src="/assets/js/head/app.js"></script>'
+      app.allocate.assets([:js, :head]).must_equal '<script type="text/javascript" src="/assets/js/head/app.js"></script>'
 
       app.compile_assets
       File.exist?(metadata_file).must_equal true
       app.allocate.assets([:js, :head]).must_match %r{src="(/assets/app\.head\.[a-f0-9]{64}\.js)"}
 
       app.plugin :assets, :compiled=>false, :precompiled=>false
-      app.allocate.assets([:js, :head]).must_equal '<script type="text/javascript"  src="/assets/js/head/app.js"></script>'
+      app.allocate.assets([:js, :head]).must_equal '<script type="text/javascript" src="/assets/js/head/app.js"></script>'
 
       app.plugin :assets, :precompiled=>metadata_file
       app.allocate.assets([:js, :head]).must_match %r{src="(/assets/app\.head\.[a-f0-9]{64}\.js)"}


### PR DESCRIPTION
As per https://github.com/jeremyevans/roda/issues/99#issuecomment-1047097595, this PR adds support for specifying the type of the script, so that the current `text/javascript` is not hardcoded. This paves the way for the `type="module"` style of scripts.

@jeremyevans Because the empty attr hash is frozen, I could not find a better way of modifying the `attires`. Do you have a better idea here?