### PR TITLE
Add :forward_response_headers option to middleware plugin

### DIFF
--- a/spec/plugin/middleware_spec.rb
+++ b/spec/plugin/middleware_spec.rb
@@ -284,5 +284,44 @@ describe "middleware plugin" do
     body('/a', 'REQUEST_METHOD'=>'PATCH').must_equal 'a2'
     body('/b', 'REQUEST_METHOD'=>'PATCH').must_equal 'b1'
   end
+
+  it "supports :forward_response_headers middleware option" do
+    mid1 = app(:bare) do
+      plugin :middleware, :forward_response_headers=>true
+
+      route do |r|
+        response.headers['A'] = 'A1'
+        response.headers['B'] = 'B1'
+      end
+    end
+
+    mid2 = app(:bare) do
+      plugin :middleware
+
+      route do |r|
+        response.headers['C'] = 'C1'
+        response.headers['D'] = 'D1'
+      end
+    end
+
+    app(:bare) do
+      use mid1
+      use mid2
+
+      route do |r|
+        response.headers['A'] = 'A2'
+        response.headers['C'] = 'C2'
+
+        r.root do
+          'body'
+        end
+      end
+    end
+
+    header('A').must_equal 'A2'
+    header('B').must_equal 'B1'
+    header('C').must_equal 'C2'
+    header('D').must_be_nil
+  end
 end
 


### PR DESCRIPTION
*Follow-up to discussion in https://github.com/jeremyevans/roda/discussions/258*

Setting the `:forward_response_headers` configuration option to `true` causes the middleware to apply response headers modified in the route block to the response of the forwarded call when the middleware didn't route the request.

```rb
class App < Roda
  plugin :middleware, forward_response_headers: true

  route do |r|
    r.get 'a' do
      # ...
    end

    # this will be merged into main app's response headers
    response.headers['Foo'] = 'Bar'
  end
end
```

This is useful in context of Rodauth, which provides methods that are expected to be called inside the route block outside of routing, some of which can modify response headers. On example is setting `Set-Cookie` to extend the remember period when logging in an account from remember token.
