### PR TITLE
Fix syntax in halt plugin example

### DIFF
--- a/lib/roda/plugins/halt.rb
+++ b/lib/roda/plugins/halt.rb
@@ -56,7 +56,7 @@ class Roda
     #     r.halt(:template) if r.params['a']
     #
     #     # symbol_views plugin, specifying status code, headers, and template file to render as body
-    #     r.halt(500, 'header=>'value', :other_template) if r.params['c']
+    #     r.halt(500, {'header'=>'value'}, :other_template) if r.params['c']
     #
     #     # json plugin, specifying status code and JSON body
     #     r.halt(500, [{'error'=>'foo'}]) if r.params['b']


### PR DESCRIPTION
This makes RDoc properly highlight that code block.
