### PR TITLE
Allow overriding exception page assets in code

### DIFF
--- a/lib/roda/plugins.rb
+++ b/lib/roda/plugins.rb
@@ -6,6 +6,7 @@ class Roda
   # Module in which all Roda plugins should be stored. Also contains logic for
   # registering and loading plugins.
   module RodaPlugins
+    NOOP = ->(*args) { args }.freeze
     OPTS = {}.freeze
     EMPTY_ARRAY = [].freeze
 

--- a/spec/plugin/exception_page_spec.rb
+++ b/spec/plugin/exception_page_spec.rb
@@ -232,4 +232,24 @@ describe "exception_page plugin" do
     h['Content-Type'].must_equal 'application/javascript'
     b.join.must_equal Roda::RodaPlugins::ExceptionPage.js
   end
+
+  it "should handle overriding exception page asset contents" do
+    app(:bare) do
+      plugin :exception_page, css: '.hello {}', js: 'console.log("hello")'
+
+      route do |r|
+        r.exception_page_assets
+      end
+    end
+
+    s, h, b = req('/exception_page.css')
+    s.must_equal 200
+    h['Content-Type'].must_equal 'text/css'
+    b.join.must_equal '.hello {}'
+
+    s, h, b = req('/exception_page.js')
+    s.must_equal 200
+    h['Content-Type'].must_equal 'application/javascript'
+    b.join.must_equal 'console.log("hello")'
+  end
 end

--- a/spec/plugin/exception_page_spec.rb
+++ b/spec/plugin/exception_page_spec.rb
@@ -235,7 +235,13 @@ describe "exception_page plugin" do
 
   it "should handle overriding exception page asset contents" do
     app(:bare) do
-      plugin :exception_page, css: '.hello {}', js: 'console.log("hello")'
+      plugin :exception_page,
+        assets: ->(css, js) {
+          css.concat("\n", 'html { background: "#facade" }')
+          js.concat("\n", 'console.log("hello")')
+
+          [css, js]
+        }
 
       route do |r|
         r.exception_page_assets
@@ -245,11 +251,11 @@ describe "exception_page plugin" do
     s, h, b = req('/exception_page.css')
     s.must_equal 200
     h['Content-Type'].must_equal 'text/css'
-    b.join.must_equal '.hello {}'
+    b.join.must_match 'html { background: "#facade" }'
 
     s, h, b = req('/exception_page.js')
     s.must_equal 200
     h['Content-Type'].must_equal 'application/javascript'
-    b.join.must_equal 'console.log("hello")'
+    b.join.must_match 'console.log("hello")'
   end
 end


### PR DESCRIPTION
While the exception page is able to use static assets, this becomes a hassle when dealing with writing Roda extensions or app frameworks based on Roda. For example, Bridgetown uses Roda and configures the exception page plugin with Bridgetown branding ... but does so with a monkey-patch to the `Roda::RodaPlugins::ExceptionPage` class.

This change gives an affordance for overriding the CSS and JavaScript content of the exception page assets, falling back to the default behavior when not configured.