### PR TITLE
Fix typo in doc-sctrings

### DIFF
--- a/lib/roda/plugins/mail_processor.rb
+++ b/lib/roda/plugins/mail_processor.rb
@@ -379,7 +379,7 @@ class Roda
         end
 
         # Perform the processing of mail for this request, first considering
-        # routes defined via the the class-level +rcpt+ method, and then the
+        # routes defined via the class-level +rcpt+ method, and then the
         # normal routing tree passed in as the block.
         def process_mail(&block)
           if string_routes = opts[:mail_processor_string_routes]

--- a/lib/roda/plugins/typecast_params.rb
+++ b/lib/roda/plugins/typecast_params.rb
@@ -346,7 +346,7 @@ class Roda
         end
 
         # The reason behind this error.  If this error was caused by a conversion method,
-        # this will be the the conversion method symbol.  If this error was caused
+        # this will be the conversion method symbol.  If this error was caused
         # because a value was missing, then it will be +:missing+.  If this error was
         # caused because a value was not the correct type, then it will be +:invalid_type+.
         attr_accessor :reason


### PR DESCRIPTION
Found by carefully reading the documentation of `typecast_params` plugin.

Thanks!