### PR TITLE
Use feature detection to find out if detailed_message is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,3 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
     - run: bundle exec rake spec_ci
-      continue-on-error: ${{ startsWith(matrix.ruby, 'truffleruby') }}

--- a/lib/roda/plugins/exception_page.rb
+++ b/lib/roda/plugins/exception_page.rb
@@ -411,7 +411,7 @@ END
 
         private
 
-        if RUBY_VERSION >= '3.2'
+        if Exception.method_defined?(:detailed_message)
           def exception_page_exception_message(exception)
             exception.detailed_message(highlight: false).to_s
           end

--- a/spec/plugin/exception_page_spec.rb
+++ b/spec/plugin/exception_page_spec.rb
@@ -15,7 +15,7 @@ describe "exception_page plugin" do
     end
   end
 
-  message = RUBY_VERSION >= '3.2' ? "foo (RuntimeError)" : "foo"
+  message = Exception.method_defined?(:detailed_message) ? "foo (RuntimeError)" : "foo"
 
   it "returns HTML page with exception information if text/html is accepted" do
     ep_app


### PR DESCRIPTION
* See https://github.com/oracle/truffleruby/issues/3257

This is necessary so that roda works on the upcoming 23.1 release (it's too late to implement `Exception#detailed_message` there, we are past the last bug fix deadline).