### PR TITLE
Set temporary name for middleware subclass

### DIFF
--- a/lib/roda/plugins/middleware.rb
+++ b/lib/roda/plugins/middleware.rb
@@ -134,6 +134,7 @@ class Roda
         # and store +app+ as the next middleware to call.
         def initialize(mid, app, *args, &block)
           @mid = Class.new(mid)
+          @mid.set_temporary_name("#{mid.name}(middleware)") if mid.name && RUBY_VERSION >= "3.3"
           if @mid.opts[:middleware_next_if_not_found]
             @mid.plugin(:not_found, &NEXT_PROC)
           end

--- a/spec/plugin/middleware_spec.rb
+++ b/spec/plugin/middleware_spec.rb
@@ -138,6 +138,26 @@ describe "middleware plugin" do
     body.must_equal 'a'
   end
 
+  it "sets temporary name of the subclass" do
+    app(:middleware) do |r|
+      r.get{self.class.name || "anonymous"}
+    end
+    a = app
+    app(:bare) do
+      use a
+      route {}
+    end
+    body.must_equal 'anonymous'
+
+    Object.const_set(:MyApp, a)
+    app(:bare) do
+      use a
+      route {}
+    end
+    body.must_equal 'MyApp(middleware)'
+    Object.send(:remove_const, :MyApp)
+  end if RUBY_VERSION >= "3.3"
+
   it "should raise error if attempting to use options for Roda application that does not support configurable middleware" do
     a1 = app(:bare){plugin :middleware}
     proc{app(:bare){use a1, :foo; route{}; build_rack_app}}.must_raise Roda::RodaError


### PR DESCRIPTION
By default it's an anonymous subclass, which doesn't communicate connection to the Roda app in the inspect output. In [rodauth-rails](https://github.com/janko/rodauth-rails/blob/7f6cd886d3af5680bf349e61941f728e5a580ff5/lib/rodauth/rails/app.rb#L10-L16), I overrode `inspect` to provide some context.

Ruby 3.3 added [`Module#set_temporary_name`](https://docs.ruby-lang.org/en/master/Module.html#method-i-set_temporary_name), which we can use to improve introspection.
