### PR TITLE
Remove `early_hints` plugin limited support caveat

### DIFF
--- a/lib/roda/plugins/early_hints.rb
+++ b/lib/roda/plugins/early_hints.rb
@@ -4,8 +4,7 @@
 class Roda
   module RodaPlugins
     # The early_hints plugin allows sending 103 Early Hints responses
-    # using the rack.early_hints environment variable.  Currently, this
-    # is only supported by puma 3.11+, and on other servers this is a no-op.
+    # using the rack.early_hints environment variable.
     # Early hints allow clients to preload necessary files before receiving
     # the response.
     module EarlyHints


### PR DESCRIPTION
Updated `early_hints` plugin documentation to remove a caveat about only Puma supporting 103 Early Hints. I think the caveat can be dropped now that folk are using newer versions of Puma and Falcon and Pitchfork have added Early Hints support.