### PR TITLE
Restore TruffleRuby CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [ "2.0.0", 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2, 3.3, 3.4, jruby-9.3, jruby-9.4 ]
+        ruby: [ "2.0.0", 2.1, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2, 3.3, 3.4, jruby-9.3, jruby-9.4, truffleruby-head ]
         include:
           - { os: ubuntu-22.04, ruby: "1.9.3" }
           - { os: ubuntu-22.04, ruby: jruby-9.1 }


### PR DESCRIPTION
Don't you mind adding TruffleRuby back as far as specs are passing now?

TruffleRuby CI was removed in 2bb51f46150c0a477b697f09b42efa29b947941a.