### PR TITLE
Correct typo "it" -> "it is"

### DIFF
--- a/lib/roda/plugins/assets.rb
+++ b/lib/roda/plugins/assets.rb
@@ -60,7 +60,7 @@ class Roda
     #   <%= assets(:css, media: 'print') %>
     #
     # The assets method will respect the application's +:add_script_name+ option,
-    # if it set it will automatically prefix the path with the +SCRIPT_NAME+ for
+    # if it is set it will automatically prefix the path with the +SCRIPT_NAME+ for
     # the request.
     #
     # == Asset Paths


### PR DESCRIPTION
I checked the codebase and chose "it is" over "it's" as it seems to be more in line with your style.

(In this file, there are 7 instances of "it is" and 0 of "it's." In the entire repo, Github has indexed 80 files containing at least one instance of "it is" and 18 files containing at least one instance of "it's.")