### PR TITLE
Add hash_public plugin for content-hash-based cache busting

### DIFF
--- a/lib/roda/plugins/hash_public.rb
+++ b/lib/roda/plugins/hash_public.rb
@@ -1,0 +1,101 @@
+# frozen-string-literal: true
+
+require 'digest/sha2'
+
+class Roda
+  module RodaPlugins
+    # The hash_public plugin adds a +hash_path+ method for constructing
+    # content-hash-based paths, and a +r.hash_public+ routing method to serve
+    # static files from a directory (using the public plugin).  This plugin is
+    # useful when you want to modify the path to static files when the content
+    # of the file changes, ensuring that requests for the static file will not
+    # be cached.
+    #
+    # Unlike the timestamp_public plugin, which uses file modification times,
+    # hash_public uses a SHA256 digest of the file content.  This makes paths
+    # stable across different build environments (e.g. Docker images built in
+    # CI/CD pipelines), where file modification times may vary even when the
+    # file content has not changed.
+    #
+    # Note that while this plugin will not serve files outside of the public
+    # directory, for performance reasons it does not check the path of the file
+    # is inside the public directory when computing the content hash.  If the
+    # +hash_path+ method is called with untrusted input, it is possible for an
+    # attacker to read the content hash of any file on the file system.
+    #
+    # Examples:
+    #
+    #   # Use public folder as location of files, and static as the path prefix
+    #   plugin :hash_public
+    #
+    #   # Use /path/to/app/static as location of files, and public as the path prefix
+    #   opts[:root] = '/path/to/app'
+    #   plugin :hash_public, root: 'static', prefix: 'public'
+    #
+    #   # Assuming public is the location of files, and static as the path prefix
+    #   route do
+    #     # Make GET /static/a1b2c3d4e5f67890/images/foo.png look for public/images/foo.png
+    #     r.hash_public
+    #
+    #     r.get "example" do
+    #       # "/static/a1b2c3d4e5f67890/images/foo.png"
+    #       hash_path("images/foo.png")
+    #     end
+    #   end
+    module HashPublic
+      # Use options given to setup content-hash-based file serving.  The
+      # following options are recognized by the plugin:
+      #
+      # :prefix :: The prefix for paths, before the hash segment
+      # :length :: The number of characters of the hex digest to use in paths
+      #            (default: full 64-character SHA256 hex digest)
+      #
+      # The options given are also passed to the public plugin.
+      def self.configure(app, opts = {})
+        app.plugin :public, opts
+        app.opts[:hash_public_prefix] = (opts[:prefix] || app.opts[:hash_public_prefix] || 'static').dup.freeze
+        app.opts[:hash_public_length] = opts[:length] || app.opts[:hash_public_length]
+        app.opts[:hash_public_cache] ||= {}
+      end
+
+      module ClassMethods
+        def freeze
+          opts[:hash_public_cache].freeze
+          super
+        end
+      end
+
+      module InstanceMethods
+        # Return a path to the static file that could be served by r.hash_public.
+        # This does not check the file is inside the directory for performance
+        # reasons, so this should not be called with untrusted input.
+        def hash_path(file)
+          cache = opts[:hash_public_cache]
+          unless hex = cache[file]
+            hex = ::Digest::SHA256.hexdigest(File.binread(File.join(opts[:public_root], file)))
+            if length = opts[:hash_public_length]
+              hex = hex[0, length]
+            end
+            cache[file] = hex.freeze
+          end
+          "/#{opts[:hash_public_prefix]}/#{hex}/#{file}"
+        end
+      end
+
+      module RequestMethods
+        # Serve files from the public directory if the file exists,
+        # it includes the hash_public prefix segment followed by
+        # a string segment for the content hash, and this is a GET request.
+        def hash_public
+          if is_get?
+            on roda_class.opts[:hash_public_prefix], String do |_|
+              public
+            end
+          end
+        end
+      end
+    end
+
+    register_plugin(:hash_public, HashPublic)
+  end
+end

--- a/spec/plugin/hash_public_spec.rb
+++ b/spec/plugin/hash_public_spec.rb
@@ -1,0 +1,127 @@
+require_relative '../spec_helper'
+
+describe 'hash_public plugin' do
+  it 'adds r.hash_public for serving static files with content-hash-based paths' do
+    app(:bare) do
+      plugin :hash_public, root: 'spec/views'
+
+      route do |r|
+        r.hash_public
+      end
+    end
+
+    status("/about/_test.erb\0").must_equal 404
+    status('/about/_test.erb').must_equal 404
+    status("/static/a/about/_test.erb\0").must_equal 404
+    body('/static/a/about/_test.erb').must_equal File.read('spec/views/about/_test.erb')
+  end
+
+  it 'supports the :prefix option' do
+    app(:bare) do
+      plugin :hash_public, root: 'spec/views', prefix: 'foo'
+
+      route do |r|
+        r.hash_public
+      end
+    end
+
+    body('/foo/a/about/_test.erb').must_equal File.read('spec/views/about/_test.erb')
+  end
+
+  it 'returns the correct hash_path with content hash' do
+    app(:bare) do
+      plugin :hash_public, root: 'spec/plugin'
+
+      route do |r|
+        r.hash_public
+        hash_path('../views/about/_test.erb')
+      end
+    end
+
+    digest = Digest::SHA256.hexdigest(File.binread('spec/views/about/_test.erb'))
+    body.must_equal "/static/#{digest}/../views/about/_test.erb"
+    status('/static/a/../views/about/_test.erb').must_equal 404
+  end
+
+  it "respects the application's :root option" do
+    app(:bare) do
+      opts[:root] = File.expand_path('..', __dir__)
+      plugin :hash_public, root: 'views'
+
+      route do |r|
+        r.hash_public
+      end
+    end
+
+    body('/static/a/about/_test.erb').must_equal File.read('spec/views/about/_test.erb')
+  end
+
+  it 'handles serving gzip files in gzip mode if client supports gzip' do
+    app(:bare) do
+      plugin :hash_public, root: 'spec/views', gzip: true
+
+      route do |r|
+        r.hash_public
+      end
+    end
+
+    body('/static/a/about/_test.erb').must_equal File.read('spec/views/about/_test.erb')
+    header(RodaResponseHeaders::CONTENT_ENCODING, '/about/_test.erb').must_be_nil
+
+    body('/static/a/about.erb').must_equal File.read('spec/views/about.erb')
+    header(RodaResponseHeaders::CONTENT_ENCODING, '/about.erb').must_be_nil
+
+    body('/static/a/about/_test.erb',
+         'HTTP_ACCEPT_ENCODING' => 'deflate, gzip').must_equal File.binread('spec/views/about/_test.erb.gz')
+    h = req('/static/a/about/_test.erb', 'HTTP_ACCEPT_ENCODING' => 'deflate, gzip')[1]
+    h[RodaResponseHeaders::CONTENT_ENCODING].must_equal 'gzip'
+    h[RodaResponseHeaders::CONTENT_TYPE].must_equal 'text/plain'
+
+    body('/static/a/about/_test.css',
+         'HTTP_ACCEPT_ENCODING' => 'deflate, gzip').must_equal File.binread('spec/views/about/_test.css.gz')
+    h = req('/static/a/about/_test.css', 'HTTP_ACCEPT_ENCODING' => 'deflate, gzip')[1]
+    h[RodaResponseHeaders::CONTENT_ENCODING].must_equal 'gzip'
+    h[RodaResponseHeaders::CONTENT_TYPE].must_equal 'text/css'
+  end
+
+  it 'returns 404 for non-GET requests' do
+    app(:bare) do
+      plugin :hash_public, root: 'spec/views', prefix: 'foo'
+
+      route do |r|
+        r.hash_public
+      end
+    end
+
+    status('/foo/a/about/_test.erb', 'REQUEST_METHOD' => 'POST').must_equal 404
+  end
+
+  it 'supports the :length option to truncate the hash' do
+    app(:bare) do
+      plugin :hash_public, root: 'spec/plugin', length: 16
+
+      route do |r|
+        r.hash_public
+        hash_path('../views/about/_test.erb')
+      end
+    end
+
+    digest = Digest::SHA256.hexdigest(File.binread('spec/views/about/_test.erb'))
+    body.must_equal "/static/#{digest[0, 16]}/../views/about/_test.erb"
+  end
+
+  it 'caches hash values for the same file' do
+    app(:bare) do
+      plugin :hash_public, root: 'spec/plugin'
+
+      route do |r|
+        r.hash_public
+        hash_path('../views/about/_test.erb')
+      end
+    end
+
+    result1 = body
+    result2 = body
+    result1.must_equal result2
+  end
+end


### PR DESCRIPTION
## Summary

- Add `hash_public` plugin that uses SHA256 content hashing for cache-busting
  paths, as an alternative to `timestamp_public` which uses file mtime
- Motivated by environments (e.g. Docker images built in CI/CD) where file
  mtime varies across builds even when content has not changed
- See Discussion https://github.com/jeremyevans/roda/discussions/417 for background

## Details

- `hash_path(file)` returns `/prefix/hexdigest/file`
- `r.hash_public` serves static files matching that path pattern
- Supports `:prefix`, `:length` (hash truncation) options
- Includes in-memory caching with `ClassMethods#freeze` support
- Tests and RDoc documentation included per CONTRIBUTING guidelines